### PR TITLE
feature/7-read-config-generic into develop

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,10 +5,10 @@ init-hook='from pylint.config import find_pylintrc;
         import os, sys;
         sys.path.append(os.path.dirname(find_pylintrc()));
         sys.path.append(os.path.join(
-                        os.path.dirname(find_pylintrc()), 'grand_trade_auto'));
+                        os.path.dirname(find_pylintrc()), 'asana_extensions'));
         sys.path.append(os.path.join(
                         os.path.join(os.path.dirname(find_pylintrc()),
-                                'grand_trade_auto'), 'general'));'
+                                'asana_extensions'), 'general'));'
 
 max-args=10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 ### Project & Toolchain: CI Support
 - [Added] `dir_init_checker.py` added to new `ci_support` dir to run code for
       checking `__init__.py` files are up to date ([#5][]).
-- [Fixed] References to previous project removed ([#1][]).
+- [Fixed] References to previous project removed ([#7][]).
 
 
 ### Project & Toolchain: CodeCov
@@ -65,16 +65,16 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 ### Project & Toolchain: Pylint
 - [Added] `.pylintrc` added to configure pylint, with source code paths added
       ([#5][]).
-- [Fixed] References to previous project removed ([#1][]).
+- [Fixed] References to previous project removed ([#7][]).
 
 
 ### General: Config
 - [Added] `config.py` added with basic `ConfigParser` file loading, including
-      without a section header; and list parsing ([#1][]).
+      without a section header; and list parsing ([#7][]).
 
 
 ### General: Dirs
-- [Added] `dirs.py` added with basic dir resolution ([#1][]).
+- [Added] `dirs.py` added with basic dir resolution ([#7][]).
 
 
 ### Docs: CHANGELOG
@@ -90,7 +90,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 ### Docs: README
 - [Changed] Updated with project intro (mostly placeholder) ([#5][]).
 - [Added] Link to `setup.md`, `usage.md`, `CONTRIBUTING.md` added ([#5][]).
-- [Added] Code cov badge added ([#1][]).
+- [Added] Code cov badge added ([#7][]).
 
 
 ### Docs: Setup
@@ -108,11 +108,12 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Project: v1.0.0](https://github.com/JonathanCasey/asana_extensions/projects/1)
 
 #### Issues
-- [#1][]
 - [#5][]
+- [#7][]
 
 #### PRs
 - [#6][] for [#5][]
+- [#8][] for [#7][]
 
 
 ---
@@ -121,6 +122,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 Reference-style links here (see below, only in source) in develop-merge order.
 
 [#5]: https://github.com/JonathanCasey/asana_extensions/issues/5 'Issue #5'
-[#1]: https://github.com/JonathanCasey/asana_extensions/issues/1 'Issue #1'
+[#7]: https://github.com/JonathanCasey/asana_extensions/issues/7 'Issue #7'
 
 [#6]: https://github.com/JonathanCasey/asana_extensions/pull/6 'PR #6'
+[#8]: https://github.com/JonathanCasey/asana_extensions/pull/8 'PR #8'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Fixed] References to previous project removed ([#1][]).
 
 
+### General: Config
+- [Added] `config.py` added with basic `ConfigParser` file loading, including
+      without a section header; and list parsing ([#1][]).
+
+
 ### General: Dirs
 - [Added] `dirs.py` added with basic dir resolution ([#1][]).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 ### Docs: README
 - [Changed] Updated with project intro (mostly placeholder) ([#5][]).
 - [Added] Link to `setup.md`, `usage.md`, `CONTRIBUTING.md` added ([#5][]).
+- [Added] Code cov badge added ([#1][]).
 
 
 ### Docs: Setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 ### Project & Toolchain: CI Support
 - [Added] `dir_init_checker.py` added to new `ci_support` dir to run code for
       checking `__init__.py` files are up to date ([#5][]).
+- [Fixed] References to previous project removed ([#1][]).
 
 
 ### Project & Toolchain: CodeCov
@@ -64,6 +65,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 ### Project & Toolchain: Pylint
 - [Added] `.pylintrc` added to configure pylint, with source code paths added
       ([#5][]).
+- [Fixed] References to previous project removed ([#1][]).
 
 
 ### General: Dirs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
       ([#5][]).
 
 
+### General: Dirs
+- [Added] `dirs.py` added with basic dir resolution ([#1][]).
+
+
 ### Docs: CHANGELOG
 - [Added] This `CHANGELOG.md` file created and updated with all project work
       to-date (+1 self reference) ([#5][]).
@@ -96,6 +100,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Project: v1.0.0](https://github.com/JonathanCasey/asana_extensions/projects/1)
 
 #### Issues
+- [#1][]
 - [#5][]
 
 #### PRs
@@ -108,5 +113,6 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 Reference-style links here (see below, only in source) in develop-merge order.
 
 [#5]: https://github.com/JonathanCasey/asana_extensions/issues/5 'Issue #5'
+[#1]: https://github.com/JonathanCasey/asana_extensions/issues/1 'Issue #1'
 
 [#6]: https://github.com/JonathanCasey/asana_extensions/pull/6 'PR #6'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CircleCI](https://circleci.com/gh/JonathanCasey/asana_extensions.svg?style=shield)](https://circleci.com/gh/JonathanCasey/asana_extensions)
+[![codecov](https://codecov.io/gh/JonathanCasey/asana_extensions/branch/develop/graph/badge.svg?token=oT627KrCf0)](https://codecov.io/gh/JonathanCasey/asana_extensions)
 
 
 # Asana Extensions

--- a/asana_extensions/general/__init__.py
+++ b/asana_extensions/general/__init__.py
@@ -1,0 +1,4 @@
+# pylint: disable=missing-module-docstring
+__all__ = [
+        'dirs',
+]

--- a/asana_extensions/general/__init__.py
+++ b/asana_extensions/general/__init__.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
+        'config',
         'dirs',
 ]

--- a/asana_extensions/general/config.py
+++ b/asana_extensions/general/config.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+This module handles access to the configuration files.  The configuration
+files--including the environment files--are accessed by the other python scripts
+through this file.
+
+This is setup such that other files need only call the `get()` functions, and
+all the loading and caching will happen automatically internal to this file.
+
+As of right now, this is hard-coded to access configuration files at a specific
+name and path.
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import configparser
+from enum import Enum
+import itertools
+import os.path
+
+from asana_extensions.general import dirs
+
+
+
+def read_conf_file_fake_header(conf_rel_file,
+        conf_base_dir=dirs.get_conf_path(), fake_section='fake',):
+    """
+    Read config file in configparser format, but insert a fake header for
+    first section.  This is aimed at files that are close to configparser
+    format, but do not have a section header for the first section.
+
+    The fake section name is not important.
+
+    Args:
+      conf_rel_file (str): Relative file path to config file.
+      conf_base_dir (str): Base file path to use with relative path.  If not
+        provided, this will use the absolute path of this module.
+      fake_section (str): Fake section name, if needed.
+
+    Returns:
+      parser (ConfigParser): ConfigParser for file loaded.
+    """
+    conf_file = os.path.join(conf_base_dir, conf_rel_file)
+
+    parser = configparser.ConfigParser()
+    with open(conf_file, encoding="utf_8") as file:
+        parser.read_file(itertools.chain(['[' + fake_section + ']'], file))
+
+    return parser
+
+
+
+def read_conf_file(conf_rel_file, conf_base_dir=dirs.get_conf_path()):
+    """
+    Read config file in configparser format.
+
+    Args:
+      conf_rel_file (str): Relative file path to config file.
+      conf_base_dir (str): Base file path to use with relative path.  If not
+        provided, this will use the absolute path of this module.
+
+    Returns:
+      parser (ConfigParser): ConfigParser for file loaded.
+    """
+    conf_file = os.path.join(conf_base_dir, conf_rel_file)
+
+    parser = configparser.ConfigParser()
+    parser.read(conf_file)
+
+    return parser
+
+
+
+class CastType(Enum):
+    """
+    Enum of cast types.
+
+    These are used to specify a target type when casting in `castVar()`.
+    """
+    INT = 'int'
+    FLOAT = 'float'
+    STRING = 'string'
+
+
+
+def cast_var(var, cast_type, fallback_to_original=False):
+    """
+    Cast variable to the specified type.
+
+    Args:
+      var (*): Variable of an unknown type.
+      cast_type (CastType): Type that var should be cast to, if possible.
+      fallback_to_original (bool): If true, will return original var if cast
+        fails; otherwise, failed cast will raise exception.
+
+    Returns:
+      var (CastType, or ?): Same as var provided, but of the type specified by
+        CastType; but if cast failed and fallback to original was true, will
+        return original var in original type.
+
+    Raises:
+      (TypeError): Cannot cast because type specified is not supported.
+      (ValueError): Cast failed and fallback to original was not True.
+    """
+    try:
+        if cast_type == CastType.INT:
+            return int(var)
+        if cast_type == CastType.FLOAT:
+            return float(var)
+        if cast_type == CastType.STRING:
+            return str(var)
+        raise TypeError('Cast failed -- unsupported type.')
+
+    except (TypeError, ValueError):
+        if fallback_to_original:
+            return var
+        raise
+
+
+
+def parse_list_from_conf_string(conf_str, val_type, delim=',',
+        strip_quotes=False):
+    """
+    Parse a string into a list of items based on the provided specifications.
+
+    Args:
+      conf_str (str): The string to be split.
+      val_type (CastType): The type to cast each element to.
+      delim (str): The delimiter on which to split conf_str.
+      strip_quotes (bool): Whether or not there are quotes to be stripped from
+        each item after split and strip.
+
+    Returns:
+      list_out (list of val_type): List of all elements found in conf_str after
+        splitting on delim.  Each element will be of val_type.  This will
+        silently skip any element that cannot be cast.
+    """
+    if not conf_str:
+        return []
+    val_raw_list = conf_str.split(delim)
+
+    list_out = []
+    for val in val_raw_list:
+        try:
+            if strip_quotes:
+                val = val.strip().strip('\'"')
+            cast_val = cast_var(val.strip(), val_type)
+            list_out.append(cast_val)
+        except (ValueError, TypeError):
+            # may have been a blank line without a delim
+            pass
+
+    return list_out

--- a/asana_extensions/general/dirs.py
+++ b/asana_extensions/general/dirs.py
@@ -7,7 +7,7 @@ project installation structure changes.
 Module Attributes:
   N/A
 
-(C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 import os.path
 

--- a/asana_extensions/general/dirs.py
+++ b/asana_extensions/general/dirs.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+This module provides an interface for getting any directory that is used
+throughout the project.  This gives a centralized place to update if the
+project installation structure changes.
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import os.path
+
+
+
+def get_root_path():
+    """
+    Get the root path to the project/repo root dir.
+
+    Returns:
+      (os.path): Path to root dir.
+    """
+    repo_root_dir = os.path.dirname(get_src_app_root_path())
+    return repo_root_dir
+
+
+
+def get_src_app_root_path():
+    """
+    Get the path to project/app source root dir.
+
+    Returns:
+      (os.path): Path to source root dir.
+    """
+    this_script_dir = os.path.dirname(os.path.realpath(__file__))
+    main_script_dir = os.path.dirname(this_script_dir)
+    return main_script_dir
+
+
+
+def get_conf_path():
+    """
+    Get the path to configuration files.
+
+    Returns:
+      (os.path): Path to config dir.
+    """
+    return os.path.join(get_root_path(), 'config')

--- a/ci_support/dir_init_checker.py
+++ b/ci_support/dir_init_checker.py
@@ -6,7 +6,7 @@ from the listing in `__init__.py` files.
 This uses python import, so this must be called from a proper python env where
 the directories-under-test are accessible.  In other words, it is best to call
 from project root as
-`python3 .circleci/dir_init_checker.py grand_trade_auto tests`.
+`python3 .circleci/dir_init_checker.py asana_extensions tests`.
 
 Entire file is excluded from unit testing / code cov; but is still linted.
 

--- a/tests/unit/general/__init__.py
+++ b/tests/unit/general/__init__.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
+        'test_config',
         'test_dirs',
 ]

--- a/tests/unit/general/__init__.py
+++ b/tests/unit/general/__init__.py
@@ -1,0 +1,4 @@
+# pylint: disable=missing-module-docstring
+__all__ = [
+        'test_dirs',
+]

--- a/tests/unit/general/test_config.py
+++ b/tests/unit/general/test_config.py
@@ -1,0 +1,126 @@
+"""
+Tests the grand_trade_auto.general.config functionality.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import os.path
+
+import pytest
+
+from asana_extensions.general import config
+
+
+
+def test_read_conf_file_fake_header():
+    """
+    Tests that the `read_conf_file_fake_header()` will correctly read a file
+    with no header, regardless of whether a fake header name was provided or the
+    default was used.
+    """
+    this_dir = os.path.dirname(os.path.realpath(__file__))
+    conf_dir = os.path.join(this_dir, 'test_config')
+    parser = config.read_conf_file_fake_header('mock_config_no_header.conf',
+            conf_dir)
+    assert parser['fake']['test key no header'] == 'test-val-no-header'
+    assert parser['test-section']['test key str'] \
+            == 'test-val-str'
+
+    parser = config.read_conf_file_fake_header('mock_config_no_header.conf',
+            conf_dir, 'new fake')
+    assert parser['new fake']['test key no header'] == 'test-val-no-header'
+    assert parser['test-section']['test key str'] \
+            == 'test-val-str'
+
+
+
+def test_read_conf_file():
+    """
+    Tests that the `read_conf_file()` will correctly read a file, checking a
+    couple values.
+    """
+    this_dir = os.path.dirname(os.path.realpath(__file__))
+    conf_dir = os.path.join(this_dir, 'test_config')
+    parser = config.read_conf_file('mock_config.conf', conf_dir)
+    assert parser['test-section']['test key str'] == 'test-val-str'
+    assert parser.getint('test-section', 'test key int') == 123
+
+
+
+def test_cast_var():
+    """
+    Tests `cast_var()` for all `CastType`, so by extention tests that enum also.
+    """
+    good_int_str = '5'
+    good_float_str = '3.14'
+    good_str = 'test str'
+    good_int = int(good_int_str)
+    good_float = float(good_float_str)
+    bad_int_str = 'five'
+    bad_float_str = 'pi'
+
+    assert good_int == config.cast_var(good_int_str, config.CastType.INT)
+    assert good_float == config.cast_var(good_float_str, config.CastType.FLOAT)
+    assert good_str == config.cast_var(good_str, config.CastType.STRING)
+
+    with pytest.raises(TypeError) as ex:
+        config.cast_var(good_int, 'invalid_cast_type')
+    assert 'Cast failed -- unsupported type.' in str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        config.cast_var(bad_int_str, config.CastType.INT)
+    assert "invalid literal for int() with base 10: 'five'" in str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        config.cast_var(bad_float_str, config.CastType.FLOAT)
+    assert "could not convert string to float: 'pi'" in str(ex.value)
+
+    # Skipping failed string cast due to expected rarity
+
+    assert bad_int_str == config.cast_var(bad_int_str, config.CastType.INT,
+            True)
+
+
+
+def test_parse_list_from_conf_string():
+    """
+    Tests `parse_list_from_conf_string()`.
+    """
+    conf_list_strs = ['one', 'two', 'three']
+    conf_str_simple = 'one, two, three'
+    conf_str_newlines = 'one,\r\ntwo,  \r\n\r\n  three'
+    conf_str_quotes = 'one, "two", \'three\''
+    conf_str_delim = 'one | two | three'
+    delim_char = '|'
+
+    conf_list_ints = [1, 2, 3]
+    conf_str_ints = '1, 2, 3'
+    conf_str_ints_mixed = '1, 1.5, 2, two-and-a-third, 3'
+    conf_list_floats = [1.0, 2.00, 3.000]
+    conf_str_floats = '1.0, 2.00, 3.000'
+
+    assert [] == config.parse_list_from_conf_string('', config.CastType.STRING)
+    assert conf_list_strs == config.parse_list_from_conf_string(
+            conf_str_simple, config.CastType.STRING)
+    assert conf_list_strs == config.parse_list_from_conf_string(
+            conf_str_newlines, config.CastType.STRING)
+    assert conf_list_strs != config.parse_list_from_conf_string(
+            conf_str_quotes, config.CastType.STRING)
+    assert conf_list_strs == config.parse_list_from_conf_string(
+            conf_str_quotes, config.CastType.STRING, strip_quotes=True)
+    assert conf_list_strs == config.parse_list_from_conf_string(
+            conf_str_delim, config.CastType.STRING, delim_char)
+
+    assert conf_list_ints == config.parse_list_from_conf_string(
+            conf_str_ints, config.CastType.INT)
+    assert conf_list_ints == config.parse_list_from_conf_string(
+            conf_str_ints_mixed, config.CastType.INT)
+    assert conf_list_floats == config.parse_list_from_conf_string(
+            conf_str_floats, config.CastType.FLOAT)

--- a/tests/unit/general/test_config/mock_config.conf
+++ b/tests/unit/general/test_config/mock_config.conf
@@ -1,0 +1,4 @@
+
+[test-section]
+test key str : test-val-str
+test key int : 123

--- a/tests/unit/general/test_config/mock_config_no_header.conf
+++ b/tests/unit/general/test_config/mock_config_no_header.conf
@@ -1,0 +1,6 @@
+
+test key no header : test-val-no-header
+
+[test-section]
+test key str : test-val-str
+test key int : 123

--- a/tests/unit/general/test_dirs.py
+++ b/tests/unit/general/test_dirs.py
@@ -11,7 +11,7 @@ Module Attributes:
   APP_NAME (str): The name of the app as it appears in its folder name in the
     repo root.
 
-(C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 import os.path
 

--- a/tests/unit/general/test_dirs.py
+++ b/tests/unit/general/test_dirs.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Tests the asana_extensions.general.dirs functionality.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  APP_NAME (str): The name of the app as it appears in its folder name in the
+    repo root.
+
+(C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import os.path
+
+from asana_extensions.general import dirs
+
+
+
+APP_NAME = 'asana_extensions'
+
+
+
+def get_root_path():
+    """
+    Gets the root path of this repo (in an alternate path/method than would
+    be done in asana_extensions.general.dirs) for use in tests.
+
+    Returns:
+      root_repo_dir (os.path): The absolute path to the repo root dir.
+    """
+    general_unit_test_dir = os.path.dirname(os.path.realpath(__file__))
+    unit_test_dir = os.path.dirname(general_unit_test_dir)
+    test_dir = os.path.dirname(unit_test_dir)
+    root_repo_dir = os.path.dirname(test_dir)
+    return root_repo_dir
+
+
+
+def test_get_root_path():
+    """
+    Tests that the `get_root_path()` method will return the correct result
+    by verifying the same result via this alternate traversal path.
+    """
+    assert get_root_path() == dirs.get_root_path()
+
+
+
+def test_get_src_app_root_path():
+    """
+    Tests that the `get_src_app_root_path()` method will return the correct
+    result by verifying the same result via this alternate traversal path.
+    """
+    src_app_root_dir = os.path.join(get_root_path(), APP_NAME)
+    assert src_app_root_dir == dirs.get_src_app_root_path()
+
+
+
+def test_get_conf_path():
+    """
+    Tests that the `get_conf_path()` method will return the correct result by
+    verifying the same result via this alternate traversal path.
+    """
+    conf_dir = os.path.join(get_root_path(), 'config')
+    assert conf_dir == dirs.get_conf_path()


### PR DESCRIPTION
This adds some basic config file reading code to facilitate next work.  Adds supports for reading config files with and without sections, reading config keys with listed items, and access specific directories.

This also adds the Code Cov badge now that there are finally unit tests to run.

Closes #7.