### PR TITLE
feature/9-asana-api-access into develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ workflows:
       - unit-tests:
           context:
             - docker-hub-creds
+            - asana-creds
   changelog-updated:
     jobs:
       - diff-changelog-last-commit:
@@ -51,7 +52,7 @@ aliases:
         environment:
           # By default there is no PYTHONPATH defined at all, so nothing to lose
           PYTHONPATH: /home/circleci/project
-  
+
   - &default_git_image
     docker:
       - image: docker:stable-git
@@ -137,6 +138,11 @@ jobs:
       - *default_restore_cache
       - *default_install_deps
       - *default_save_cache
+      - run:
+          name: Setup mock files
+          command: |
+            echo -e '\n[asana]\n' >> config/.secrets.conf
+            echo -e 'personal access token : $ASANA_PERSONAL_ACCESS_TOKEN\n'  >> config/.secrets.conf
       - run:
           name: Run pytest unit tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
           name: Setup mock files
           command: |
             echo -e '\n[asana]\n' >> config/.secrets.conf
-            echo -e 'personal access token : $ASANA_PERSONAL_ACCESS_TOKEN\n'  >> config/.secrets.conf
+            echo -e 'personal access token : '$ASANA_PERSONAL_ACCESS_TOKEN'\n'  >> config/.secrets.conf
       - run:
           name: Run pytest unit tests
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 ### Project & Toolchain: CircleCI
 - [Added] CircleCI implemented, with `.circleci/config.yml` file that ensures
       project builds successfully ([#5][]).
+- [Added] `asana-creds` added as context for unit tests, with setup of mock
+      files to load access token into secrets conf ([#9][]).
 
 
 ### Project & Toolchain: CI Support
@@ -68,6 +70,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Added] `requirements.txt` added, with `pylint`,  `pytest`, `pytest-cov` as
       only entries ([#5][]).
 - [Added] `python-dateutil` added to `requirements.txt` ([#1][]).
+- [Added] `asana` added to `requirements.txt` ([#9][]).
 
 
 ### Project & Toolchain: Pylint
@@ -76,6 +79,16 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Fixed] References to previous project removed ([#7][]).
 - [Added] `trailing_commas` plugin added, with options to ignore `if`, tuples,
       and functions ([#13][]).
+
+
+### Asana: Asana Client
+- [Added] `asana_client.py` added, with initial `_get_client()` management
+      method and `_get_me()` helper method imlpemented ([#9][]).
+
+
+### Config: .secrets.conf
+- [Added] `.secrets.conf` file created (with `.default` stub), with `asana`
+      section for personal access token key added ([#9][]).
 
 
 ### Config: rules.conf
@@ -122,6 +135,8 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Added] `CONTRIBUTING.md` added to project root; relevant parts from
       `setup.md` and `usage.md` migrated ([#5][]).
 - [Changed] `pytest` workflow command updated to use coverage output ([#13][]).
+- [Removed] The `test` `env` is not applicable to this project and references
+      have been removed ([#9][]).
 
 
 ### Docs: README
@@ -152,6 +167,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#1][]
 - [#5][]
 - [#7][]
+- [#9][]
 - [#12][]
 - [#13][]
 
@@ -160,6 +176,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#8][] for [#7][]
 - [#11][] for [#1][], [#12][]
 - [#14][] for [#13][]
+- [#15][] for [#9][]
 
 
 ---
@@ -172,8 +189,10 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#1]: https://github.com/JonathanCasey/asana_extensions/issues/1 'Issue #1'
 [#12]: https://github.com/JonathanCasey/asana_extensions/issues/12 'Issue #12'
 [#13]: https://github.com/JonathanCasey/asana_extensions/issues/13 'Issue #13'
+[#9]: https://github.com/JonathanCasey/asana_extensions/issues/9 'Issue #9'
 
 [#6]: https://github.com/JonathanCasey/asana_extensions/pull/6 'PR #6'
 [#8]: https://github.com/JonathanCasey/asana_extensions/pull/8 'PR #8'
 [#11]: https://github.com/JonathanCasey/asana_extensions/pull/11 'PR #11'
 [#14]: https://github.com/JonathanCasey/asana_extensions/pull/14 'PR #14'
+[#15]: https://github.com/JonathanCasey/asana_extensions/pull/15 'PR #15'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,6 @@ are required in their respective config files in order to run the relevant
 unit tests:
 - (TBD)
 
-The `env` for each of those must be `test`.
-
 Note that some test WILL make API calls, so it will count against any rate
 limiting or quotas.
 

--- a/asana_extensions/asana/__init__.py
+++ b/asana_extensions/asana/__init__.py
@@ -1,0 +1,4 @@
+# pylint: disable=missing-module-docstring
+__all__ = [
+        'asana_client',
+]

--- a/asana_extensions/asana/asana_client.py
+++ b/asana_extensions/asana/asana_client.py
@@ -51,7 +51,7 @@ def _get_client():
 
 def _get_me():
     """
-    Gets the data for 'me' (self).
+    Gets the data for 'me' (self) user.
 
     At this time, only here for testing API connection, as it is the most basic
     way to test API access is working.
@@ -61,7 +61,8 @@ def _get_me():
         full schema here: https://developers.asana.com/docs/user
 
     Raises:
-      (asana.error.NoAuthorizationError):
+      (asana.error.NoAuthorizationError): Personal access token was missing or
+        invalid.
     """
     # pylint: disable=no-member     # asana.Client dynamically adds attrs
     client = _get_client()

--- a/asana_extensions/asana/asana_client.py
+++ b/asana_extensions/asana/asana_client.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Asana client wrapper.  This will manage the client connection state and expose
+methods to be called for specific
+
+Module Attributes:
+  logger (Logger): Logger for this module.
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import logging
+
+import asana
+
+from asana_extensions.general import config
+
+
+
+_client = None
+
+
+
+def _ensure_client_ready():
+    """
+    Ensures the client is initialized and ready for use.
+
+    Sets the module's client attribute.
+    """
+    global _client
+    if _client is None:
+        parser = config.read_conf_file('.secrets.conf')
+        pat = parser['asana']['personal access token']
+        _client = asana.Client.access_token(pat)

--- a/asana_extensions/asana/asana_client.py
+++ b/asana_extensions/asana/asana_client.py
@@ -20,15 +20,54 @@ logger = logging.getLogger(__name__)
 
 
 
+class ClientCreationError(Exception):
+    """
+    Raised when the client fails to be created for any reason.
+    """
+
+
+
 def _get_client():
     """
     Ensures the client is initialized and ready for use.
 
     Returns:
       (Client): Asana client, either the previously cached one or a new one.
+
+    Raises:
+      (ClientCreationError): Failed to create client for any reason.
     """
     if not hasattr(_get_client, 'client') or _get_client.client is None:
-        parser = config.read_conf_file('.secrets.conf')
-        pat = parser['asana']['personal access token']
-        _get_client.client = asana.Client.access_token(pat)
+        try:
+            parser = config.read_conf_file('.secrets.conf')
+            pat = parser['asana']['personal access token']
+            _get_client.client = asana.Client.access_token(pat)
+        except KeyError as ex:
+            raise ClientCreationError('Could not create client - Could not find'
+                    + f' necessary section/key in .secrets.conf: {ex}') from ex
     return _get_client.client
+
+
+
+def _get_me():
+    """
+    Gets the data for 'me' (self).
+
+    At this time, only here for testing API connection, as it is the most basic
+    way to test API access is working.
+
+    Returns:
+      ({str: str/int/dict/etc}): The data for the 'me' (self) user.  See
+        full schema here: https://developers.asana.com/docs/user
+
+    Raises:
+      (asana.error.NoAuthorizationError):
+    """
+    # pylint: disable=no-member     # asana.Client dynamically adds attrs
+    client = _get_client()
+    try:
+        return client.users.me()
+    except asana.error.NoAuthorizationError as ex:
+        logger.error('Failed to access API in _get_me() - Not Authorized:'
+                + f' {ex}')
+        raise

--- a/asana_extensions/asana/asana_client.py
+++ b/asana_extensions/asana/asana_client.py
@@ -16,18 +16,19 @@ from asana_extensions.general import config
 
 
 
-_client = None
+logger = logging.getLogger(__name__)
 
 
 
-def _ensure_client_ready():
+def _get_client():
     """
     Ensures the client is initialized and ready for use.
 
-    Sets the module's client attribute.
+    Returns:
+      (Client): Asana client, either the previously cached one or a new one.
     """
-    global _client
-    if _client is None:
+    if not hasattr(_get_client, 'client') or _get_client.client is None:
         parser = config.read_conf_file('.secrets.conf')
         pat = parser['asana']['personal access token']
-        _client = asana.Client.access_token(pat)
+        _get_client.client = asana.Client.access_token(pat)
+    return _get_client.client

--- a/config/stubs/.secrets.conf.default
+++ b/config/stubs/.secrets.conf.default
@@ -1,0 +1,8 @@
+
+[asana]
+# This app uses personal access tokens.  One can be generated from your account
+#  via "My Settings" > "Apps" > "Manage Developer Apps"
+# This should land on this page: https://app.asana.com/0/developer-console
+# More info should be available here:
+#  https://developers.asana.com/docs/personal-access-token
+personal access token : # <pat>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+asana
 pylint
 pytest
 pytest-cov

--- a/tests/unit/asana/__init__.py
+++ b/tests/unit/asana/__init__.py
@@ -1,0 +1,4 @@
+# pylint: disable=missing-module-docstring
+__all__ = [
+        'test_asana_client',
+]

--- a/tests/unit/asana/test_asana_client.py
+++ b/tests/unit/asana/test_asana_client.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Tests the asana_extensions.asana.asana_client functionality.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+#pylint: disable=protected-access  # Allow for purpose of testing those elements
+
+import logging
+
+import asana
+import pytest
+
+from asana_extensions.asana import asana_client
+from asana_extensions.general import config
+
+
+
+@pytest.fixture(name='mock_read_conf_file_bad_pat')
+def fixture_mock_read_conf_file_bad_pat():
+    """
+    A mock function to monkeypatch in to read a conf file with a bad personal
+    access token.
+
+    Returns:
+      (method): Returns a method that will mock reading the conf file.  Intended
+        to be monkeypatched in for the equivalent method in config.
+    """
+    def mock_read_conf_file(conf_rel_file,     # pylint: disable=unused-argument
+            conf_base_dir=None):               # pylint: disable=unused-argument
+        """
+        """
+        return {
+            'asana': {
+                'personal access token': 'bad pat',
+            },
+        }
+
+    return mock_read_conf_file
+
+
+
+def test__get_client(monkeypatch):
+    """
+    Tests the `_get_client()` method.
+
+    This relies on /config/.secrets.conf being setup with a real personal access
+    token.
+    """
+    client = asana_client._get_client()
+    assert client is not None
+
+    def mock_read_conf_file(conf_rel_file,     # pylint: disable=unused-argument
+            conf_base_dir=None):               # pylint: disable=unused-argument
+        """
+        Return an empty dict instead of loading from file.
+        """
+        return {}
+
+    # read_conf_file() returning bad config allows to confirm client cache works
+    monkeypatch.setattr(config, 'read_conf_file', mock_read_conf_file)
+    client = asana_client._get_client()
+    assert client is not None
+
+    monkeypatch.delattr(asana_client._get_client, 'client')
+    with pytest.raises(asana_client.ClientCreationError) as ex:
+        asana_client._get_client()
+    assert "Could not create client - Could not find necessary section/key in" \
+            + " .secrets.conf: 'asana'" in str(ex.value)
+
+
+
+def test__get_me(monkeypatch, caplog, mock_read_conf_file_bad_pat):
+    """
+    Tests the `_get_me()` method.
+
+    This relies on /config/.secrets.conf being setup with a real personal access
+    token.
+
+    ** Consumes 2 API calls. **
+    """
+    caplog.set_level(logging.WARNING)
+
+    me_data = asana_client._get_me()
+    assert me_data['gid']
+
+    monkeypatch.delattr(asana_client._get_client, 'client')
+    monkeypatch.setattr(config, 'read_conf_file', mock_read_conf_file_bad_pat)
+    caplog.clear()
+    with pytest.raises(asana.error.NoAuthorizationError):
+        asana_client._get_me()
+    assert caplog.record_tuples == [
+            ('asana_extensions.asana.asana_client', logging.ERROR,
+                "Failed to access API in _get_me() - Not Authorized:"
+                + " No Authorization: Not Authorized"),
+    ]


### PR DESCRIPTION
This adds the initial API support for Asana.  This makes a connection just to confirm it works.  It also adds the `.secrets.conf` for storing the personal access token for asana.

Closes #9.