### PR TITLE
feature/25-aclient-wrapping into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,33 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
       "me" ([#10][]).
 - [Added] Added method to get the list of sections (as gids) in a project or
       user task list ([#10][]).
+- [Added] `@asana_error_handler` decorator added to wrap exception handling
+      for asana API requests (just logs and raises) ([#25][]).
+  - Adds a `_is_wrapped_by_asana_error_handler` to function for test purposes.
+- [Changed] All functions that make API requests directly now decorated with
+      `@asana_error_handler` and all existing relevant exception handling
+      removed from those functions ([#25][]).
+
+##### Unit Tests
+- [Changed] `fixture_raise_no_authorization_error` and
+      `fixture_raise_not_found_error` removed in favor of a general
+      `fixture_raise_asana_error` ([#25][]).
+  - Uses an `asana_error_data` pytest marker to allow customization of
+        exception by test using it.
+- [Changed] `fixture_section_in_project_test` is now
+      `fixture_sections_in_project_test`, supports 2 sections ([#25][]).
+  - This also means it now returns a list of dicts.  Relevant tests updated.
+- [Added] `subtest_asana_error_handler_func()` added, intended to be called in
+      test of every function decorated with `@asana_error_handler` ([#25][]).
+  - Test cases for these functions updated to call this new method in
+        combination with `asana_error_data` pytest marker.
+- [Added] `test_asana_error_handler()` added for direct test of decorator
+      ([#25][]).
+- [Added] `test_dec_usage_asana_error_handler()` added for simple parametrized
+      testing of all functions decorated with `@asana_error_handler` to ensure
+      they are decorated as expected ([#25][]).
+- [Added] `test_pagination` added to ensure pagination does not cause any issues
+      with this project (really an integration test) ([#25][]).
 
 
 ### Asana: Utils
@@ -223,6 +250,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#12][]
 - [#13][]
 - [#16][]
+- [#25][]
 - [#27][]
 
 #### PRs
@@ -234,6 +262,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#17][] for [#16][]
 - [#26][] for [#10][]
 - [#29][] for [#27][]
+- [#30][] for [#25][]
 
 
 ---
@@ -250,6 +279,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#16]: https://github.com/JonathanCasey/asana_extensions/issues/16 'Issue #16'
 [#10]: https://github.com/JonathanCasey/asana_extensions/issues/10 'Issue #10'
 [#27]: https://github.com/JonathanCasey/asana_extensions/issues/27 'Issue #27'
+[#25]: https://github.com/JonathanCasey/asana_extensions/issues/25 'Issue #25'
 
 [#6]: https://github.com/JonathanCasey/asana_extensions/pull/6 'PR #6'
 [#8]: https://github.com/JonathanCasey/asana_extensions/pull/8 'PR #8'
@@ -259,3 +289,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#17]: https://github.com/JonathanCasey/asana_extensions/pull/17 'PR #17'
 [#26]: https://github.com/JonathanCasey/asana_extensions/pull/26 'PR #26'
 [#29]: https://github.com/JonathanCasey/asana_extensions/pull/29 'PR #29'
+[#30]: https://github.com/JonathanCasey/asana_extensions/pull/30 'PR #30'

--- a/asana_extensions/asana/client.py
+++ b/asana_extensions/asana/client.py
@@ -108,7 +108,8 @@ def _get_me():
         full schema here: https://developers.asana.com/docs/user
 
     Raises:
-      (asana.error.AsanaError): Any errors from the API.
+      (asana.error.AsanaError): Any errors from the API not handled by
+        `@asana_error_handler`.
     """
     # pylint: disable=no-member     # asana.Client dynamically adds attrs
     client = _get_client()
@@ -194,6 +195,7 @@ def get_workspace_gid_from_name(ws_name, ws_gid=None):
 
 
 
+@asana_error_handler
 def get_project_gid_from_name(ws_gid, proj_name, proj_gid=None, archived=False):
     """
     This will get the project gid from the name.  It will confirm the name is
@@ -212,8 +214,8 @@ def get_project_gid_from_name(ws_gid, proj_name, proj_gid=None, archived=False):
       (int): The only gid that matches this project name.
 
     Raises:
-      (asana.error.NoAuthorizationError): Personal access token was missing or
-        invalid.
+      (asana.error.AsanaError): Any errors from the API not handled by
+        `@asana_error_handler`.
     """
     # pylint: disable=no-member     # asana.Client dynamically adds attrs
     params = {
@@ -223,17 +225,12 @@ def get_project_gid_from_name(ws_gid, proj_name, proj_gid=None, archived=False):
         params['archived'] = archived
 
     client = _get_client()
-    try:
-        projects = client.projects.get_projects(params)
-    except asana.error.NoAuthorizationError as ex:
-        logger.error('Failed to access API in get_project_gid_from_name() -'
-                + f' Not Authorized: {ex}')
-        raise
-
+    projects = client.projects.get_projects(params)
     return _find_gid_from_name(projects, 'project', proj_name, proj_gid)
 
 
 
+@asana_error_handler
 def get_section_gid_from_name(proj_or_utl_gid, sect_name, sect_gid=None):
     """
     This will get the section gid from the name.  It will confirm the name is
@@ -252,22 +249,17 @@ def get_section_gid_from_name(proj_or_utl_gid, sect_name, sect_gid=None):
       (int): The only gid that matches this section name.
 
     Raises:
-      (asana.error.NoAuthorizationError): Personal access token was missing or
-        invalid.
+      (asana.error.AsanaError): Any errors from the API not handled by
+        `@asana_error_handler`.
     """
     # pylint: disable=no-member     # asana.Client dynamically adds attrs
     client = _get_client()
-    try:
-        sections = client.sections.get_sections_for_project(proj_or_utl_gid)
-    except asana.error.NoAuthorizationError as ex:
-        logger.error('Failed to access API in get_section_gid_from_name() -'
-                + f' Not Authorized: {ex}')
-        raise
-
+    sections = client.sections.get_sections_for_project(proj_or_utl_gid)
     return _find_gid_from_name(sections, 'section', sect_name, sect_gid)
 
 
 
+@asana_error_handler
 def get_user_task_list_gid(workspace_gid, is_me=False, user_gid=None):
     """
     Gets the "project ID" for the user task list, either by "me" or a specific
@@ -285,10 +277,9 @@ def get_user_task_list_gid(workspace_gid, is_me=False, user_gid=None):
       (int): The gid of the user task list for the provided user.
 
     Raises:
+      (asana.error.AsanaError): Any errors from the API not handled by
+        `@asana_error_handler`.
       (AssertionError): Invalid data.
-      (asana.error.NoAuthorizationError): Personal access token was missing or
-        invalid.
-      (asana.error.NotFoundError): Invalid/inaccessible user gid provided.
     """
     # pylint: disable=no-member     # asana.Client dynamically adds attrs
     assert is_me ^ (user_gid is not None), 'Must provide `is_me` or' \
@@ -302,22 +293,13 @@ def get_user_task_list_gid(workspace_gid, is_me=False, user_gid=None):
     }
 
     client = _get_client()
-    try:
-        utl_data = client.user_task_lists.get_user_task_list_for_user(
-                str(user_gid), params)
-    except asana.error.NoAuthorizationError as ex:
-        logger.error('Failed to access API in get_user_task_list_gid() -'
-                + f' Not Authorized: {ex}')
-        raise
-    except asana.error.NotFoundError as ex:
-        logger.error('Could not find requested data'
-                + f' in get_user_task_list_gid(): {ex}')
-        raise
-
+    utl_data = client.user_task_lists.get_user_task_list_for_user(
+            str(user_gid), params)
     return int(utl_data['gid'])
 
 
 
+@asana_error_handler
 def get_section_gids_in_project_or_utl(proj_or_utl_gid):
     """
     This gets the list of section gids in a project or user task list.
@@ -332,17 +314,10 @@ def get_section_gids_in_project_or_utl(proj_or_utl_gid):
         list.
 
     Raises:
-      (asana.error.NoAuthorizationError): Personal access token was missing or
-        invalid.
+      (asana.error.AsanaError): Any errors from the API not handled by
+        `@asana_error_handler`.
     """
     # pylint: disable=no-member     # asana.Client dynamically adds attrs
     client = _get_client()
-    try:
-        sections = client.sections.get_sections_for_project(proj_or_utl_gid)
-    except asana.error.NoAuthorizationError as ex:
-        logger.error('Failed to access API in'
-                + ' get_section_gids_in_project_or_utl() -'
-                + f' Not Authorized: {ex}')
-        raise
-
+    sections = client.sections.get_sections_for_project(proj_or_utl_gid)
     return [int(s['gid']) for s in sections]

--- a/asana_extensions/asana/client.py
+++ b/asana_extensions/asana/client.py
@@ -68,11 +68,7 @@ def asana_error_handler(f):
                     + f' [{ex.status}] {ex.message}')
             raise
 
-    setattr(wrapper, f'_is_wrapped_by_{wrapper.__qualname__}', True)
-    wrapper._is_wrapped_by_asana_error_handler = True
-    if not hasattr(wrapper, '_wrapped_by'):
-        wrapper._wrapped_by = []
-    wrapper._wrapped_by.append('asana_error_handler')
+    wrapper._is_wrapped_by_asana_error_handler = True #pylint: disable=protected-access
     return wrapper
 
 

--- a/asana_extensions/asana/client.py
+++ b/asana_extensions/asana/client.py
@@ -167,6 +167,7 @@ def _find_gid_from_name(data, resource_type, name, expected_gid=None):
 
 
 
+@asana_error_handler
 def get_workspace_gid_from_name(ws_name, ws_gid=None):
     """
     This will get the workspace gid from the name.  It will confirm the name is
@@ -183,18 +184,12 @@ def get_workspace_gid_from_name(ws_name, ws_gid=None):
       (int): The only gid that matches this workspace name.
 
     Raises:
-      (asana.error.NoAuthorizationError): Personal access token was missing or
-        invalid.
+      (asana.error.AsanaError): Any errors from the API not handled by
+        `@asana_error_handler`.
     """
     # pylint: disable=no-member     # asana.Client dynamically adds attrs
     client = _get_client()
-    try:
-        workspaces = client.workspaces.get_workspaces()
-    except asana.error.NoAuthorizationError as ex:
-        logger.error('Failed to access API in get_workspace_gid_from_name() -'
-                + f' Not Authorized: {ex}')
-        raise
-
+    workspaces = client.workspaces.get_workspaces()
     return _find_gid_from_name(workspaces, 'workspace', ws_name, ws_gid)
 
 

--- a/tests/unit/asana/test_client.py
+++ b/tests/unit/asana/test_client.py
@@ -174,6 +174,36 @@ def test_logging_capture_warnings(caplog):
 
 
 
+def test_asana_error_handler(caplog):
+    """
+    Tests the `@asana_error_handler` decorator.
+    """
+    caplog.set_level(logging.ERROR)
+
+    def gen_text(text1, text2, text3):
+        return f'{text1} | {text2} | {text3}'
+
+    dec_gen_text = aclient.asana_error_handler(gen_text)
+    assert dec_gen_text('one', text3='three', text2='two') \
+            == 'one | two | three'
+    assert dec_gen_text._is_wrapped_by_asana_error_handler is True
+
+    def raise_error(exception_type):
+        raise exception_type
+
+    dec_raise_error = aclient.asana_error_handler(raise_error)
+    exception_types = [
+        asana.error.PremiumOnlyError,
+        asana.error.RateLimitEnforcedError,
+    ]
+    for exception_type in exception_types:
+        subtest_asana_error_handler_func(caplog, exception_type, 0,
+                dec_raise_error, exception_type)
+
+    assert dec_raise_error._is_wrapped_by_asana_error_handler is True
+
+
+
 @pytest.mark.parametrize('func_name', [
     '_get_me',
 ])

--- a/tests/unit/asana/test_client.py
+++ b/tests/unit/asana/test_client.py
@@ -327,7 +327,7 @@ def test__find_gid_from_name(caplog):
 
 
 
-@pytest.mark.asana_error_data(asana.error.ForbiddenError)
+@pytest.mark.asana_error_data.with_args(asana.error.ForbiddenError)
 def test_get_workspace_gid_from_name(monkeypatch, caplog,
         raise_asana_error):
     """


### PR DESCRIPTION
This changes the `client` code in `asana` to use a decorator `@asana_error_handler` to perform the default handling of asana API errors.  This drastically reduces duplicated code and simplifies testing (albeit adds some complexity to the test configuration).

This also adds a test to ensure pagination is being handled gracefully.

Closes #25.