### PR TITLE
feature/18-task-sel-filt into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,10 +100,17 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 
 ### Asana / Meta
 
+##### Unit Tests: conftest
+- [Added] Added `conftest.py` to root of `asana` subpackage in unit tests dir,
+      with new `fixture_sections_in_utl_test()` added for use by other modules
+      in subpackage ([#18][]).
+
+
 ##### Unit Tests: Tester Data
 - [Added] `tester_data.py` added to hold test data constants, initially
       including the `_WORKSPACE`, `_PROJECT_TEMPLATE`, and `_SESSIONS_TEMPLATE`
       constants ([#10][]).
+- [Added] `_TASK_TEMPLATE` added for naming test tasks ([#18][]).
 
 
 ### Asana: Client
@@ -127,6 +134,8 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Changed] All functions that make API requests directly now decorated with
       `@asana_error_handler` and all existing relevant exception handling
       removed from those functions ([#25][]).
+- [Added] `get_tasks()` method added to get tasks from asana API based on given
+      criteria ([#18][]).
 
 ##### Unit Tests
 - [Changed] `fixture_raise_no_authorization_error` and
@@ -148,6 +157,10 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
       they are decorated as expected ([#25][]).
 - [Added] `test_pagination` added to ensure pagination does not cause any issues
       with this project (really an integration test) ([#25][]).
+- [Changed] Improved looping syntax by iterating by item, not be index in some
+      places ([#18][]).
+- [Added] `fixture_tasks_in_project_and_utl_test()` added to create tasks for
+      testing `get_tasks()` method (so far) ([#18][]).
 
 
 ### Asana: Utils
@@ -156,6 +169,15 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Added] `DataConflictError` and `DataMissingError` exceptions added ([#10][]).
 - [Added] Method to get the net included section gids based on project contents
       and explicit includes/excludes added ([#10][]).
+- [Added] `get_filtered_tasks()` added to filter tasks based on due date/time in
+      a given section, including factoring in timezone as best as API will
+      allow ([#18][]).
+- [Added] `_filter_tasks_by_datetime()` and `_filter_tasks_by_completed` added
+      to support specific filter processing of `get_filtered_tasks()` ([#18][]).
+
+##### Unit Tests
+- [Added] `fixture_tasks_with_due_in_utl_test()` added for testing task
+      filtering (so far) ([#18][]).
 
 
 ### Config: .secrets.conf
@@ -169,6 +191,8 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Fixed] Correct description that `for my tasks list` and `user task list id`
       cannot be provided together, now matching code ([#10][]).
 - [Fixed] Cleaned up comments not meant to be committed.
+- [Added] `assumed time for min due` and `assumed time for max due` added along
+      with explanation of usage ([#18][]).
 
 
 ### General: Config
@@ -177,6 +201,8 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Changed] `conf_base_dir` parameter in `read_conf_file_fake_header()`,
       `read_conf_file()` changed to `None`, with the real default set within the
       method body to better support testing ([#1][]).
+- [Added] `UnsupportedFormatError` added for cases where a config value is in
+      a parsable format, but it's use as such is not supported ([#18][]).
 
 
 ### General: Dirs
@@ -187,6 +213,11 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Added] `exceptions.py` added with `TimeframeArgDupeError` ([#1][]).
 
 
+### General: Utils
+- [Added] `utils.py` added, with `is_date_only()` check, which only supports
+      ISO 8601 strings and `relativedelta` input only ([#18][]).
+
+
 ### Rules / Meta
 - [Added] `rule_meta.py` added with abstract `Rule` defining interface and some
       consolidated logic ([#1][]).
@@ -194,11 +225,27 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Added] `rules.py` added with `load_all_from_config()` started to load all
       rules from the `rules.conf` file ([#1][]).
 - [Added] `MoveTasksRule` added to `_RULES` list in `rules.py` ([#1][]).
+- [Added] `parse_time_arg()` added to parse time-only iso-format values (not
+      full ISO 8601 format though) ([#18][]).
+- [Changed] `parse_timedelta_arg()` will now also return `None` if an empty
+      string is provided in case key is left in config but is blank ([#18][]).
 
 
 ### Rules: Move Tasks Rule
 - [Added] `move_tasks_rule.py` added with `MoveTasksRule` having initial logic
       to load from config and do non-API validation ([#1][]).
+- [Added] Support for `assumed time for min/max due` config parameters added,
+      with catch of `UnsupportedFormatError` ([#18][]).
+- [Fixed] Updated incorrect parameter name in error message ([#18][]).
+- [Changed] References to timeframe in error messages changed to be `timeframe`
+      instead of `time` to be more clear and distinuish from assumed time errors
+      ([#18][]).
+
+##### Unit Tests
+- [Changed] `[test-move-tasks-full-is-utl-and-gid]` is now split into
+      `[test-move-tasks-is-utl-and-gid]` and `[test-move-tasks-full]` to ensure
+      that if `full` is changed later, no need to worry about it reducing
+      coverage ([#18][]).
 
 
 ### Docs: CHANGELOG
@@ -252,6 +299,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#12][]
 - [#13][]
 - [#16][]
+- [#18][]
 - [#25][]
 - [#27][]
 - [#28][]
@@ -267,6 +315,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#29][] for [#27][]
 - [#30][] for [#25][]
 - [#31][] for [#28][]
+- [#32][] for [#18][]
 
 
 ---
@@ -285,6 +334,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#27]: https://github.com/JonathanCasey/asana_extensions/issues/27 'Issue #27'
 [#25]: https://github.com/JonathanCasey/asana_extensions/issues/25 'Issue #25'
 [#28]: https://github.com/JonathanCasey/asana_extensions/issues/28 'Issue #28'
+[#18]: https://github.com/JonathanCasey/asana_extensions/issues/18 'Issue #18'
 
 [#6]: https://github.com/JonathanCasey/asana_extensions/pull/6 'PR #6'
 [#8]: https://github.com/JonathanCasey/asana_extensions/pull/8 'PR #8'
@@ -296,3 +346,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#29]: https://github.com/JonathanCasey/asana_extensions/pull/29 'PR #29'
 [#30]: https://github.com/JonathanCasey/asana_extensions/pull/30 'PR #30'
 [#31]: https://github.com/JonathanCasey/asana_extensions/pull/31 'PR #31'
+[#32]: https://github.com/JonathanCasey/asana_extensions/pull/32 'PR #32'

--- a/asana_extensions/asana/client.py
+++ b/asana_extensions/asana/client.py
@@ -321,3 +321,43 @@ def get_section_gids_in_project_or_utl(proj_or_utl_gid):
     client = _get_client()
     sections = client.sections.get_sections_for_project(proj_or_utl_gid)
     return [int(s['gid']) for s in sections]
+
+
+
+@asana_error_handler
+def get_tasks(params, fields=None):
+    """
+    Get tasks, including the fields specified, that match the parameters
+    provided.
+
+    See https://developers.asana.com/docs/get-multiple-tasks for list of
+    `params` keys and which combinations are required at a minimum.
+
+    As far as possible fields, this is unclear in the API, but the data to
+    create a task: https://developers.asana.com/docs/create-a-task is likely the
+    best hint.
+
+    Args:
+      params ({str:str}): The dict of parameters to pass to the asana API for
+        the query.  See API docs referenced above.  Note that values must all be
+        strings (i.e. ints must be cast to str before passing in here).
+      fields ([str]): The list of fields to get from the API for each task.  If
+        omitted, the `gid`, `resource_type`, and `name` will be returned.  The
+        `gid` is always returned and does not need to be specified here.
+        (Unsure where to find list of options for this, but best guess is
+        linked above).
+
+    Returns:
+      ([{str:str/list/dict}]): List of tasks, with each element being a dict of
+        values.
+
+    Raises:
+      (asana.error.AsanaError): Any errors from the API not handled by
+        `@asana_error_handler`.
+    """
+    # pylint: disable=no-member     # asana.Client dynamically adds attrs
+    client = _get_client()
+    options = {}
+    if fields is not None:
+        options['opt_fields'] = fields
+    return client.tasks.get_tasks(params, **options)

--- a/asana_extensions/asana/utils.py
+++ b/asana_extensions/asana/utils.py
@@ -153,7 +153,7 @@ def get_net_include_section_gids(              # pylint: disable=too-many-locals
 def get_filtered_tasks(section_gid, match_no_due_date=False,
         min_time_until_due=None, max_time_until_due=None,
         min_time_due_assumed=None, max_time_due_assumed=None,
-        use_tzinfo=None):
+        use_tzinfo=None, dt_base=None):
     """
     Gets tasks in a given section that meet the due filter criteria provided.
 
@@ -195,6 +195,10 @@ def get_filtered_tasks(section_gid, match_no_due_date=False,
         done based with timezone factored in.  See docstring in
         `_filter_tasks_by_datetime()` for more info and an example of how this
         is used.
+      dt_base (datetime or None): This is the time to use as the base time for
+        comparing relative time.  It should usually be the time now.  This is
+        largely here for unit test purposes, but it is possible to modify if
+        really desired...
 
     Returns:
       filt_tasks ([{str:str}]): The tasks that meet the filter criteria, with
@@ -219,10 +223,12 @@ def get_filtered_tasks(section_gid, match_no_due_date=False,
     if match_no_due_date:
         return [t for t in sect_tasks if t['due_on'] is None]
 
-    now_with_tz = dt.datetime.now().astimezone(use_tzinfo)
-    filt_tasks = _filter_tasks_by_datetime(sect_tasks, now_with_tz,
+    if dt_base is None:
+        dt_base = dt.datetime.now()
+    dt_base_with_tz = dt_base.astimezone(use_tzinfo)
+    filt_tasks = _filter_tasks_by_datetime(sect_tasks, dt_base_with_tz,
             min_time_until_due, operator.ge, min_time_due_assumed)
-    filt_tasks = _filter_tasks_by_datetime(filt_tasks, now_with_tz,
+    filt_tasks = _filter_tasks_by_datetime(filt_tasks, dt_base_with_tz,
             max_time_until_due, operator.le, max_time_due_assumed)
     return filt_tasks
 

--- a/asana_extensions/asana/utils.py
+++ b/asana_extensions/asana/utils.py
@@ -217,7 +217,7 @@ def get_filtered_tasks(section_gid, match_no_due_date=False,
     sect_tasks = aclient.get_tasks(params, fields)
 
     if match_no_due_date:
-        return [t for t in sect_tasks if t['due_at'] is None]
+        return [t for t in sect_tasks if t['due_on'] is None]
 
     now_with_tz = dt.datetime.now().astimezone(use_tzinfo)
     filt_tasks = _filter_tasks_by_datetime(sect_tasks, now_with_tz,

--- a/asana_extensions/asana/utils.py
+++ b/asana_extensions/asana/utils.py
@@ -201,7 +201,9 @@ def get_filtered_tasks(section_gid, match_no_due_date=False,
         each task being a dict of values based on the API key/values.
     """
     assert match_no_due_date \
-            ^ (min_time_until_due is not None or max_time_until_due is not None)
+            ^ (min_time_until_due is not None \
+                or max_time_until_due is not None), \
+            'Must provide min/max until due or specify no due date but not both'
 
     params = {
         'section': section_gid,

--- a/asana_extensions/general/__init__.py
+++ b/asana_extensions/general/__init__.py
@@ -3,4 +3,5 @@ __all__ = [
         'config',
         'dirs',
         'exceptions',
+        'utils',
 ]

--- a/asana_extensions/general/config.py
+++ b/asana_extensions/general/config.py
@@ -24,6 +24,14 @@ from asana_extensions.general import dirs
 
 
 
+class UnsupportedFormatError(Exception):
+    """
+    Raised when parsing any argument and it is in an invalid format (and is not
+    covered by a more specific or more appropriate error).
+    """
+
+
+
 def read_conf_file_fake_header(conf_rel_file, conf_base_dir=None,
         fake_section='fake',):
     """

--- a/asana_extensions/general/utils.py
+++ b/asana_extensions/general/utils.py
@@ -41,7 +41,8 @@ def is_date_only(dt_var):
         # Inspired by logic check for relativedelta._has_time in source:
         # https://dateutil.readthedocs.io/en/stable/_modules/dateutil/relativedelta.html
         return (not dt_var.hours and not dt_var.minutes and not dt_var.seconds
-                and not dt_var.microseconds)
+                and not dt_var.microseconds and dt_var.hour is None
+                and dt_var.minute is None and dt_var.microsecond is None)
 
     try:
         dt.date.fromisoformat(dt_var)

--- a/asana_extensions/general/utils.py
+++ b/asana_extensions/general/utils.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+General utility functions for the project that do not fit in another other
+more-specific sub-package.
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import datetime as dt
+
+from dateutil.relativedelta import relativedelta
+
+
+
+def is_date_only(dt_var):
+    """
+    Check whether the provided variable is a date-only format provided that
+    format is supported.
+
+    This does NOT rely on hack methods of checking such as looking a datetime
+    object having 0 for hours and minutes since that could be the same as a
+    datetime at midnight.
+
+    Args:
+      dt_var (relativedelta/str): A datetime variable that may be a date, time,
+        or datetime.  Supported types and formats are:
+          - relativedelta
+          - ISO 8601 string
+
+    Returns:
+      (bool): True if definitely a date only; False if definitely a time or
+        datetime.
+
+    Raises:
+      (NotImplementedError): The type or format of the provided `dt_var` arg is
+        not supported.
+    """
+    if isinstance(dt_var, relativedelta):
+        # Inspired by logic check for relativedelta._has_time in source:
+        # https://dateutil.readthedocs.io/en/stable/_modules/dateutil/relativedelta.html
+        return (not dt_var.hours and not dt_var.minutes and not dt_var.seconds
+                and not dt_var.microseconds)
+
+    try:
+        dt.date.fromisoformat(dt_var)
+        return True
+    except ValueError:
+        try:
+            dt.datetime.fromisoformat(dt_var)
+            return False
+        except ValueError:
+            # Not an ISO date nor time -- fall thru to check other types
+            pass
+    except TypeError:
+        # Not a string to try ISO date/time -- fall thru to check other types
+        pass
+
+    raise NotImplementedError('Datetime format provided to `is_date_only()`'
+            + f' is not supported at this time: {dt_var}')

--- a/asana_extensions/rules/move_tasks_rule.py
+++ b/asana_extensions/rules/move_tasks_rule.py
@@ -57,7 +57,7 @@ class MoveTasksRule(rule_meta.Rule):
                 or rule_params['project_gid'] is not None
         assert rule_params['is_my_tasks_list'] is False \
                 or rule_params['user_task_list_gid'] is None, "Cannot" \
-                    + " specify 'is my tasks list' and 'user task list gid'" \
+                    + " specify 'for my tasks list' and 'user task list gid'" \
                     + " together."
         is_user_task_list_given = rule_params['is_my_tasks_list'] \
                 or rule_params['user_task_list_gid'] is not None
@@ -179,7 +179,7 @@ class MoveTasksRule(rule_meta.Rule):
             return None
         except TimeframeArgDupeError as ex:
             logger.error('Failed to parse Move Tasks Rule from config.  Check'
-                    + f' time args.  Exception: {str(ex)}')
+                    + f' timeframe args.  Exception: {str(ex)}')
             return None
         except ValueError as ex:
             logger.error('Failed to parse Move Tasks Rule from config.  Check'

--- a/asana_extensions/rules/move_tasks_rule.py
+++ b/asana_extensions/rules/move_tasks_rule.py
@@ -128,6 +128,8 @@ class MoveTasksRule(rule_meta.Rule):
             rule_params['workspace_gid'] = rules_cp.getint(rule_id,
                     'workspace gid', fallback=None)
 
+            rule_params['match_no_due_date'] = rules_cp.getboolean(rule_id,
+                    'no due date', fallback=False)
             rule_params['min_time_until_due_str'] = rules_cp.get(rule_id,
                     'min time until due', fallback=None)
             rule_params['min_time_until_due'] = cls.parse_timedelta_arg(
@@ -136,8 +138,14 @@ class MoveTasksRule(rule_meta.Rule):
                     'max time until due', fallback=None)
             rule_params['max_time_until_due'] = cls.parse_timedelta_arg(
                     rule_params['max_time_until_due_str'])
-            rule_params['match_no_due_date'] = rules_cp.getboolean(rule_id,
-                    'no due date', fallback=False)
+            rule_params['min_due_assumed_time_str'] = rules_cp.get(rule_id,
+                    'assumed time for min due', fallback=None)
+            rule_params['min_due_assumed_time'] = cls.parse_time_arg(
+                    rule_params['min_due_assumed_time_str'], None)
+            rule_params['max_due_assumed_time_str'] = rules_cp.get(rule_id,
+                    'assumed time for max due', fallback=None)
+            rule_params['max_due_assumed_time'] = cls.parse_time_arg(
+                    rule_params['max_due_assumed_time_str'], None)
 
             rule_params['src_sections_include_names'] = \
                     config.parse_list_from_conf_string(rules_cp.get(rule_id,
@@ -161,6 +169,10 @@ class MoveTasksRule(rule_meta.Rule):
             rule_params['dst_section_gid'] = rules_cp.getint(rule_id,
                     'dst section gid', fallback=None)
 
+        except config.UnsupportedFormatError as ex:
+            logger.error('Failed to parse Move Tasks Rule from config.  Check'
+                    + f' time args.  Exception: {str(ex)}')
+            return None
         except KeyError as ex:
             logger.error('Failed to parse Move Tasks Rule from config.  Check'
                     + f' keys.  Exception: {str(ex)}')

--- a/asana_extensions/rules/rule_meta.py
+++ b/asana_extensions/rules/rule_meta.py
@@ -16,12 +16,14 @@ Module Attributes:
 (C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 from abc import ABC, abstractmethod
+import datetime as dt
 import logging
 import re
 import string
 
 from dateutil.relativedelta import relativedelta
 
+from asana_extensions.general import config
 from asana_extensions.general.exceptions import *   # pylint: disable=wildcard-import
 
 
@@ -126,6 +128,54 @@ class Rule(ABC):
           ([str]): A list of names that are valid to use as the type for this
             rule.
         """
+
+
+
+    @classmethod
+    def parse_time_arg(cls, t_str, is_tz_required=False):
+        """
+        Parses a simple ISO format time string.  This does NOT have exhaustive
+        ISO 8601 format.
+
+        Args:
+          t_str (str or None): The string to parse a time value.  None allowed
+            for convenience.
+          is_tz_allowed (bool or None): Whether the time string is required to
+            have timezone information.  True and False mean required and not
+            required, respectively.  If None, it is required that the timezone
+            is NOT provided at all.
+
+        Returns:
+          time_parsed (time or None): The time object parsed from the time
+            string provided, with the timezone enforced as specified.  If None
+            or empty string provided, None returned.
+
+        Raises:
+          (config.UnsupportedFormatError): Raised if timezone information is
+            incompatible between the time string provided and the timezone
+            requirement specified.  Specifically, this is raised if timezone is
+            required and there is no timezone parsed from the string; or if
+            timezone is prohibited (None) and there is a timezone parsed from
+            the string.
+          (ValueError): Raised if not a valid ISO format time string.
+        """
+        assert is_tz_required is True or is_tz_required is False \
+                or is_tz_required is None, \
+                '`is_tz_required` must be bool or None'
+
+        if t_str is None or t_str == '':
+            return None
+
+        time_parsed = dt.time.fromisoformat(t_str)
+        if is_tz_required is True and time_parsed.tzinfo is None:
+            raise config.UnsupportedFormatError('Timezone required for time'
+                    + f" string, but none found.  String: '{t_str}',"
+                    + f' parsed: `{time_parsed}`')
+        if is_tz_required is None and time_parsed.tzinfo is not None:
+            raise config.UnsupportedFormatError('Timezone prohibited for time'
+                    + f" string, but one was provided.  String: '{t_str}',"
+                    + f' parsed: `{time_parsed}`')
+        return time_parsed
 
 
 

--- a/asana_extensions/rules/rule_meta.py
+++ b/asana_extensions/rules/rule_meta.py
@@ -156,12 +156,12 @@ class Rule(ABC):
 
         Returns:
           (relativedelta or None): The relative datetime delta specified by the
-                string.  If None was passed in, None is returned.
+                string.  If None or empty string passed in, None is returned.
 
         Raises:
           Will pass thru any exceptions raised from timeframe parser.
         """
-        if arg_str is None:
+        if arg_str is None or arg_str == '':
             return None
 
         kwargs = {}

--- a/config/stubs/rules.conf.default
+++ b/config/stubs/rules.conf.default
@@ -32,6 +32,10 @@ workspace gid : # <id>
 # `min time until due` will default to beginning of time.
 # `max time until due` will default to end of time.
 # `min/max time until due` are inclusive bounds.
+# `only use datetime field` will only include tasks that have the date+time
+#  field populated in Asana, omitting tasks that have only a date.  This is
+#  ignored if `min/max time until due` do not have any time durations or if
+#  `no due date` is used.
 # Timeframe keys can be given in short or long form, with or without space
 #  separators, plural or singular.  Value must precede timeframe.  Only the
 #  short form is case sensitive.  Keys as `<short>, <long>` are:
@@ -50,6 +54,7 @@ workspace gid : # <id>
 # - Upcoming month, excluding upcoming week: `min: 1w1d, max: 1M`
 min time until due : # <timeframe>
 max time until due : # <timeframe>
+only use datetime field : # <YES/no>
 no due date : # <yes/NO>
 
 # Source sections to include and/or exclude can be specified by name or ID.
@@ -100,6 +105,10 @@ workspace gid : # <id>
 # `min time until due` will default to beginning of time.
 # `max time until due` will default to end of time.
 # `min/max time until due` are inclusive bounds.
+# `only use datetime field` will only include tasks that have the date+time
+#  field populated in Asana, omitting tasks that have only a date.  This is
+#  ignored if `min/max time until due` do not have any time durations or if
+#  `no due date` is used.
 # Timeframe keys can be given in short or long form, with or without space
 #  separators, plural or singular.  Value must precede timeframe.  Only the
 #  short form is case sensitive.  Keys as `<short>, <long>` are:
@@ -118,6 +127,7 @@ workspace gid : # <id>
 # - Upcoming month, excluding upcoming week: `min: 1w1d, max: 1M`
 min time until due : # <timeframe>
 max time until due : # <timeframe>
+only use datetime field : # <YES/no>
 no due date : # <yes/NO>
 
 # Source sections to include and/or exclude can be specified by name or ID.

--- a/config/stubs/rules.conf.default
+++ b/config/stubs/rules.conf.default
@@ -32,10 +32,18 @@ workspace gid : # <id>
 # `min time until due` will default to beginning of time.
 # `max time until due` will default to end of time.
 # `min/max time until due` are inclusive bounds.
-# `only use datetime field` will only include tasks that have the date+time
-#  field populated in Asana, omitting tasks that have only a date.  This is
-#  ignored if `min/max time until due` do not have any time durations or if
-#  `no due date` is used.
+# `assumed time for min/max due` will use the provided time if the task does not
+#   have a due time, combining it with the task's due date.  This is ignored if
+#  `min/max time until due` do not have any time durations or if `no due date`
+#  is used.  Omitting this when time durations are used will result in only
+#  tasks with due times to be included (effectively, omitting just 1 of these
+#  parameters will exclude date-only due dates).
+# As hinted above, handling is different whether or not `min/max time until due`
+#  have any time duration args (minute, hour).  Using `0` for these values won't
+#  work to count as including a time duration, so if want to target 'now'
+#  (i.e. the current time), something like `-1m` will work.  Cutting things so
+#  close that a minute would make or break would not be recommended anyways due
+#  to script execution time.
 # Timeframe keys can be given in short or long form, with or without space
 #  separators, plural or singular.  Value must precede timeframe.  Only the
 #  short form is case sensitive.  Keys as `<short>, <long>` are:
@@ -52,10 +60,11 @@ workspace gid : # <id>
 # - All before yesterday =  `max: -2d`
 # - Upcoming week, excluding today: `min: 1d, max: 1w`
 # - Upcoming month, excluding upcoming week: `min: 1w1d, max: 1M`
+no due date : # <yes/NO>
 min time until due : # <timeframe>
 max time until due : # <timeframe>
-only use datetime field : # <YES/no>
-no due date : # <yes/NO>
+assumed time for min due : # <HH:MM> or delete
+assumed time for max due : # <HH:MM> or delete
 
 # Source sections to include and/or exclude can be specified by name or ID.
 # Inclusion means tasks in these section will be moved.
@@ -105,10 +114,18 @@ workspace gid : # <id>
 # `min time until due` will default to beginning of time.
 # `max time until due` will default to end of time.
 # `min/max time until due` are inclusive bounds.
-# `only use datetime field` will only include tasks that have the date+time
-#  field populated in Asana, omitting tasks that have only a date.  This is
-#  ignored if `min/max time until due` do not have any time durations or if
-#  `no due date` is used.
+# `assumed time for min/max due` will use the provided time if the task does not
+#   have a due time, combining it with the task's due date.  This is ignored if
+#  `min/max time until due` do not have any time durations or if `no due date`
+#  is used.  Omitting this when time durations are used will result in only
+#  tasks with due times to be included (effectively, omitting just 1 of these
+#  parameters will exclude date-only due dates).
+# As hinted above, handling is different whether or not `min/max time until due`
+#  have any time duration args (minute, hour).  Using `0` for these values won't
+#  work to count as including a time duration, so if want to target 'now'
+#  (i.e. the current time), something like `-1m` will work.  Cutting things so
+#  close that a minute would make or break would not be recommended anyways due
+#  to script execution time.
 # Timeframe keys can be given in short or long form, with or without space
 #  separators, plural or singular.  Value must precede timeframe.  Only the
 #  short form is case sensitive.  Keys as `<short>, <long>` are:
@@ -125,10 +142,11 @@ workspace gid : # <id>
 # - All before yesterday =  `max: -2d`
 # - Upcoming week, excluding today: `min: 1d, max: 1w`
 # - Upcoming month, excluding upcoming week: `min: 1w1d, max: 1M`
+no due date : # <yes/NO>
 min time until due : # <timeframe>
 max time until due : # <timeframe>
-only use datetime field : # <YES/no>
-no due date : # <yes/NO>
+assumed time for min due : # <HH:MM> or delete
+assumed time for max due : # <HH:MM> or delete
 
 # Source sections to include and/or exclude can be specified by name or ID.
 # Inclusion means tasks in these section will be moved.

--- a/tests/unit/asana/__init__.py
+++ b/tests/unit/asana/__init__.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
+        'conftest',
         'test_client',
         'test_utils',
         'tester_data',

--- a/tests/unit/asana/conftest.py
+++ b/tests/unit/asana/conftest.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Configures pytest as needed.  This file normally does not need to exist, but is
+used here to share and configure items for the /tests/unit/asana subpackage.
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+#pylint: disable=protected-access  # Allow for purpose of testing those elements
+
+import uuid
+
+import pytest
+
+from asana_extensions.asana import client as aclient
+from tests.unit.asana import tester_data
+
+
+
+@pytest.fixture(name='sections_in_utl_test', scope='session')
+def fixture_sections_in_utl_test():
+    """
+    Creates some test sections in the user task list (in the test workspace) and
+    returns a list of them, each of which is the dict of data that should match
+    the `data` element returned by the API.
+
+    Will delete the sections once done with all tests.
+
+    This is not being used with the autouse keyword so that, if running tests
+    that do not require this section fixture, they can run more optimally
+    without the need to needlessly create and delete this section.  (Also,
+    could not figure out how to get rid of all syntax and pylint errors).
+
+    ** Consumes at least 7 API calls. **
+    (API call count is 2*num_sects + at least 3)
+    (varies depending on data size, but only 7 calls intended)
+    """
+    # pylint: disable=no-member     # asana.Client dynamically adds attrs
+    num_sects = 2
+    client = aclient._get_client()
+    me_data = aclient._get_me()
+    ws_gid = aclient.get_workspace_gid_from_name(tester_data._WORKSPACE)
+    utl_gid = str(aclient.get_user_task_list_gid(ws_gid, is_me=True))
+
+    sect_data_list = []
+    for _ in range(num_sects):
+        sect_name = tester_data._SECTION_TEMPLATE.substitute(
+                {'sid': uuid.uuid4()})
+        params = {
+            'name': sect_name,
+            'owner': me_data['gid'],
+        }
+        sect_data = client.sections.create_section_for_project(utl_gid, params)
+        sect_data_list.append(sect_data)
+
+    yield sect_data_list
+
+    for sect_data in sect_data_list:
+        client.sections.delete_section(sect_data['gid'])

--- a/tests/unit/asana/test_client.py
+++ b/tests/unit/asana/test_client.py
@@ -124,49 +124,6 @@ def fixture_sections_in_project_test(project_test):
 
 
 
-@pytest.fixture(name='sections_in_utl_test', scope='session')
-def fixture_sections_in_utl_test():
-    """
-    Creates some test sections in the user task list (in the test workspace) and
-    returns a list of them, each of which is the dict of data that should match
-    the `data` element returned by the API.
-
-    Will delete the sections once done with all tests.
-
-    This is not being used with the autouse keyword so that, if running tests
-    that do not require this section fixture, they can run more optimally
-    without the need to needlessly create and delete this section.  (Also,
-    could not figure out how to get rid of all syntax and pylint errors).
-
-    ** Consumes at least 7 API calls. **
-    (API call count is 2*num_sects + at least 3)
-    (varies depending on data size, but only 7 calls intended)
-    """
-    # pylint: disable=no-member     # asana.Client dynamically adds attrs
-    num_sects = 2
-    client = aclient._get_client()
-    me_data = aclient._get_me()
-    ws_gid = aclient.get_workspace_gid_from_name(tester_data._WORKSPACE)
-    utl_gid = str(aclient.get_user_task_list_gid(ws_gid, is_me=True))
-
-    sect_data_list = []
-    for _ in range(num_sects):
-        sect_name = tester_data._SECTION_TEMPLATE.substitute(
-                {'sid': uuid.uuid4()})
-        params = {
-            'name': sect_name,
-            'owner': me_data['gid'],
-        }
-        sect_data = client.sections.create_section_for_project(utl_gid, params)
-        sect_data_list.append(sect_data)
-
-    yield sect_data_list
-
-    for sect_data in sect_data_list:
-        client.sections.delete_section(sect_data['gid'])
-
-
-
 @pytest.fixture(name='tasks_in_project_and_utl_test', scope='session')
 def fixture_tasks_in_project_and_utl_test(project_test,
         sections_in_project_test, sections_in_utl_test):

--- a/tests/unit/asana/test_client.py
+++ b/tests/unit/asana/test_client.py
@@ -677,8 +677,9 @@ def test_get_section_gids_in_project_or_utl(monkeypatch, caplog, project_test,
 
 
 @pytest.mark.asana_error_data.with_args(asana.error.NoAuthorizationError)
-def test_get_tasks(monkeypatch, caplog, project_test, sections_in_project_test,
-        sections_in_utl_test, tasks_in_project_and_utl_test, raise_asana_error):
+def test_get_tasks(monkeypatch, caplog,        # pylint: disable=too-many-locals
+        project_test, sections_in_project_test, sections_in_utl_test,
+        tasks_in_project_and_utl_test, raise_asana_error):
     """
     Tests the `get_tasks()` method.
 
@@ -740,6 +741,7 @@ def test_get_tasks(monkeypatch, caplog, project_test, sections_in_project_test,
     }
     fields = [
         'due_on',
+        'memberships.section',
         'name',
         'projects',
     ]
@@ -759,6 +761,9 @@ def test_get_tasks(monkeypatch, caplog, project_test, sections_in_project_test,
         assert task_found['due_on'] is None
         assert task_found['name'] == task_expected['name']
         assert task_found['projects'][0]['gid'] == project_test['gid']
+        assert sections_in_project_test[0]['gid'] in \
+                [m['section']['gid'] for m in task_found['memberships'] \
+                    if 'section' in m]
 
     # Function-specific practical test of @asana_error_handler
     client = aclient._get_client()

--- a/tests/unit/asana/test_client.py
+++ b/tests/unit/asana/test_client.py
@@ -86,8 +86,9 @@ def fixture_project_test():
 @pytest.fixture(name='sections_in_project_test', scope='session')
 def fixture_sections_in_project_test(project_test):
     """
-    Creates some test sections and returns a list of them, each of which is the
-    dict of data that should match the 'data' element returned by the API.
+    Creates some test sections in the test project and returns a list of them,
+    each of which is the dict of data that should match the `data` element
+    returned by the API.
 
     Will delete the sections once done with all tests.
 
@@ -118,8 +119,103 @@ def fixture_sections_in_project_test(project_test):
 
     yield sect_data_list
 
-    for i in range(num_sects):
-        client.sections.delete_section(sect_data_list[i]['gid'])
+    for sect_data in sect_data_list:
+        client.sections.delete_section(sect_data['gid'])
+
+
+
+@pytest.fixture(name='sections_in_utl_test', scope='session')
+def fixture_sections_in_utl_test():
+    """
+    Creates some test sections in the user task list (in the test workspace) and
+    returns a list of them, each of which is the dict of data that should match
+    the `data` element returned by the API.
+
+    Will delete the sections once done with all tests.
+
+    This is not being used with the autouse keyword so that, if running tests
+    that do not require this section fixture, they can run more optimally
+    without the need to needlessly create and delete this section.  (Also,
+    could not figure out how to get rid of all syntax and pylint errors).
+
+    ** Consumes at least 7 API calls. **
+    (API call count is 2*num_sects + at least 3)
+    (varies depending on data size, but only 7 calls intended)
+    """
+    # pylint: disable=no-member     # asana.Client dynamically adds attrs
+    num_sects = 2
+    client = aclient._get_client()
+    me_data = aclient._get_me()
+    ws_gid = aclient.get_workspace_gid_from_name(tester_data._WORKSPACE)
+    utl_gid = str(aclient.get_user_task_list_gid(ws_gid, is_me=True))
+
+    sect_data_list = []
+    for _ in range(num_sects):
+        sect_name = tester_data._SECTION_TEMPLATE.substitute(
+                {'sid': uuid.uuid4()})
+        params = {
+            'name': sect_name,
+            'owner': me_data['gid'],
+        }
+        sect_data = client.sections.create_section_for_project(utl_gid, params)
+        sect_data_list.append(sect_data)
+
+    yield sect_data_list
+
+    for sect_data in sect_data_list:
+        client.sections.delete_section(sect_data['gid'])
+
+
+
+@pytest.fixture(name='tasks_in_project_and_utl_test', scope='session')
+def fixture_tasks_in_project_and_utl_test(project_test,
+        sections_in_project_test, sections_in_utl_test):
+    """
+    Creates some tasks in both the user task list (in the test workspace) and
+    the test project, and returns a list of them, each of which is the dict of
+    data that should match the `data` element returned by the API.  The tasks
+    in the user task list and the test project are the same tasks.
+
+    Will delete the tasks once done with all tests.
+
+    This is not being used with the autouse keyword so that, if running tests
+    that do not require this section fixture, they can run more optimally
+    without the need to needlessly create and delete this section.  (Also,
+    could not figure out how to get rid of all syntax and pylint errors).
+
+    ** Consumes 7 API calls. **
+    (API call count is 3*num_sects + 1)
+    """
+    # pylint: disable=no-member     # asana.Client dynamically adds attrs
+    num_tasks = 2
+    client = aclient._get_client()
+    me_data = aclient._get_me()
+
+    task_data_list = []
+    for _ in range(num_tasks):
+        task_name = tester_data._TASK_TEMPLATE.substitute({'tid': uuid.uuid4()})
+        params = {
+            'assignee': me_data['gid'],
+            'assignee_section': sections_in_utl_test[0]['gid'],
+            'name': task_name,
+            'projects': [
+                project_test['gid'],
+            ],
+        }
+        task_data = client.tasks.create_task(params)
+        task_data_list.append(task_data)
+
+        # No way to add project section at task creation, so need separate call
+        params = {
+            'task': task_data['gid'],
+        }
+        client.sections.add_task_for_section(sections_in_project_test[0]['gid'],
+                params)
+
+    yield task_data_list
+
+    for task_data in task_data_list:
+        client.tasks.delete_task(task_data['gid'])
 
 
 
@@ -210,6 +306,7 @@ def test_asana_error_handler(caplog):
     'get_section_gid_from_name',
     'get_user_task_list_gid',
     'get_section_gids_in_project_or_utl',
+    'get_tasks',
 ])
 def test_dec_usage_asana_error_handler(func_name):
     """
@@ -576,6 +673,67 @@ def test_get_section_gids_in_project_or_utl(monkeypatch, caplog, project_test,
             raise_asana_error)
     subtest_asana_error_handler_func(caplog, asana.error.InvalidRequestError, 0,
             aclient.get_section_gids_in_project_or_utl, project_test['gid'])
+
+
+
+@pytest.mark.asana_error_data.with_args(asana.error.NoAuthorizationError)
+def test_get_tasks(monkeypatch, caplog, project_test, sections_in_project_test,
+        sections_in_utl_test, tasks_in_project_and_utl_test):
+    """
+    Tests the `get_tasks()` method.
+
+    This does require the asana account be configured to support unit testing.
+    See CONTRIBUTING.md.
+
+    ** Consumes at least 3 API call. **
+    (varies depending on data size, but only 3 calls intended)
+
+    Raises:
+      (TesterNotInitializedError): If test workspace does not exist on asana
+        account tied to access token, will stop test.  User must create
+        manually per docs.
+    """
+    # pylint: disable=no-member     # asana.Client dynamically adds attrs
+    caplog.set_level(logging.ERROR)
+
+    try:
+        me_data = aclient._get_me()
+    except aclient.DataNotFoundError as ex:
+        # This is an error with the tester, not the module under test
+        raise TesterNotInitializedError('Cannot run unit tests: Must create a'
+                + f' workspace named "{tester_data._WORKSPACE}" in the asana'
+                + ' account tied to access token in .secrets.conf') from ex
+
+    client = aclient._get_client()
+    ws_gid = aclient.get_workspace_gid_from_name(tester_data._WORKSPACE)
+
+    params = {
+        'assignee': me_data['gid'],
+        'workspace': ws_gid,
+    }
+    fields = [
+        'assignee_section',
+        'due_at',
+        'name',
+        'projects',
+    ]
+    tasks_found = aclient.get_tasks(params, fields)
+    # Filter/match list since other tests may have added more tasks to server
+    tasks_to_check = {}
+    for task_found in tasks_found:
+        for i_task_expected, task_expected in enumerate(
+                tasks_in_project_and_utl_test):
+            if task_found['gid'] == task_expected['gid']:
+                tasks_to_check[i_task_expected] = task_found
+                break
+    assert len(tasks_to_check) == len(tasks_in_project_and_utl_test)
+    for i_task_expected, task_found in tasks_to_check.items():
+        task_expected = tasks_in_project_and_utl_test[i_task_expected]
+        assert task_found['assignee_section']['gid'] \
+                    == sections_in_utl_test[0]['gid']
+        assert task_found['due_at'] is None
+        assert task_found['name'] == task_expected['name']
+        assert task_found['projects'][0]['gid'] == project_test['gid']
 
 
 

--- a/tests/unit/asana/test_utils.py
+++ b/tests/unit/asana/test_utils.py
@@ -196,7 +196,7 @@ def test_get_filtered_tasks( # pylint: disable=too-many-locals, too-many-stateme
     `test__filter_tasks_by_datetime()`, with the last task here with no due date
     being the primary difference.
 
-    ** Consumes at least 12 API calls. **
+    ** Consumes at least 13 API calls. **
     (varies depending on data size, but only 10 calls intended)
     """
     with pytest.raises(AssertionError) as ex:
@@ -240,21 +240,19 @@ def test_get_filtered_tasks( # pylint: disable=too-many-locals, too-many-stateme
     assumed_time_2 = dt.time(23, 30)
 
     filt_tasks = autils.get_filtered_tasks(sect_gid, False, rd_date_today,
-            rd_date_today, assumed_time_1, dt_base=dt_base_1)
+            rd_date_today, assumed_time_1, use_tzinfo=tzinfo_1,
+            dt_base=dt_base_1)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
-    print('test tasks:')
-    print('-----------')
-    for task in tasks_with_due_in_utl_test:
-        print()
-        print(task)
-    print()
-    print()
-    print('tasks to check:')
-    print('---------------')
-    for task in tasks_to_check:
-        print()
-        print(task)
-    print()
+    assert {created_task_gids[i] for i in [0, 3, 5, 6]} \
+            == {t['gid'] for t in tasks_to_check}
+
+    # To test if the use_tzinfo default arg is work, need to compensate based
+    #  on system timezone and re-call previous test.
+    tz_diff = dt_base_1.utcoffset() - dt_base_1.astimezone(None).utcoffset()
+    dt_base_1_tz_diffed = dt_base_1 + tz_diff
+    filt_tasks = autils.get_filtered_tasks(sect_gid, False, rd_date_today,
+            rd_date_today, dt_base=dt_base_1_tz_diffed)
+    tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
     assert {created_task_gids[i] for i in [0, 3, 5, 6]} \
             == {t['gid'] for t in tasks_to_check}
 
@@ -265,56 +263,61 @@ def test_get_filtered_tasks( # pylint: disable=too-many-locals, too-many-stateme
             == {t['gid'] for t in tasks_to_check}
 
     filt_tasks = autils.get_filtered_tasks(sect_gid, False, rd_date_today,
-            rd_date_today, is_completed=True, dt_base=dt_base_1)
+            rd_date_today, is_completed=True, use_tzinfo=tzinfo_1,
+            dt_base=dt_base_1)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
     assert {created_task_gids[i] for i in [8]} \
             == {t['gid'] for t in tasks_to_check}
 
     filt_tasks = autils.get_filtered_tasks(sect_gid, False, rd_date_today,
-            rd_date_today, is_completed=None, dt_base=dt_base_1)
+            rd_date_today, is_completed=None, use_tzinfo=tzinfo_1,
+            dt_base=dt_base_1)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
     assert {created_task_gids[i] for i in [0, 3, 5, 6, 8]} \
             == {t['gid'] for t in tasks_to_check}
 
     filt_tasks = autils.get_filtered_tasks(sect_gid, False, rd_date_today,
-            rd_date_tomorrow, None, assumed_time_1, dt_base=dt_base_1)
+            rd_date_tomorrow, None, assumed_time_1, use_tzinfo=tzinfo_1,
+            dt_base=dt_base_1)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
     assert {created_task_gids[i] for i in [0, 2, 3, 4, 5, 6]} \
             == {t['gid'] for t in tasks_to_check}
 
     filt_tasks = autils.get_filtered_tasks(sect_gid, False, None,
-            rd_date_yesterday, dt_base=dt_base_1)
+            rd_date_yesterday, use_tzinfo=tzinfo_1, dt_base=dt_base_1)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
     assert {created_task_gids[i] for i in [1]} \
             == {t['gid'] for t in tasks_to_check}
 
     filt_tasks = autils.get_filtered_tasks(sect_gid, False, rd_date_tomorrow,
-            None, dt_base=dt_base_1)
+            None, use_tzinfo=tzinfo_1, dt_base=dt_base_1)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
     assert {created_task_gids[i] for i in [2, 4]} \
             == {t['gid'] for t in tasks_to_check}
 
     filt_tasks = autils.get_filtered_tasks(sect_gid, False, rd_datetime_1m_ago,
-            rd_datetime_2h_later, assumed_time_1, dt_base=dt_base_1)
+            rd_datetime_2h_later, assumed_time_1, use_tzinfo=tzinfo_1,
+            dt_base=dt_base_1)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
     assert {created_task_gids[i] for i in [3, 5]} \
             == {t['gid'] for t in tasks_to_check}
 
     filt_tasks = autils.get_filtered_tasks(sect_gid, False, rd_datetime_1m_ago,
             rd_datetime_2h_later, assumed_time_1, assumed_time_1,
-            dt_base=dt_base_1)
+            use_tzinfo=tzinfo_1, dt_base=dt_base_1)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
     assert {created_task_gids[i] for i in [0, 3, 5]} \
             == {t['gid'] for t in tasks_to_check}
 
     filt_tasks = autils.get_filtered_tasks(sect_gid, False,
             rd_datetime_yesterday_and_1m_ago, rd_datetime_2h_later,
-            assumed_time_1, assumed_time_2, dt_base=dt_base_1)
+            assumed_time_1, assumed_time_2, use_tzinfo=tzinfo_1,
+            dt_base=dt_base_1)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
     assert {created_task_gids[i] for i in [1, 3, 5, 6]} \
             == {t['gid'] for t in tasks_to_check}
 
-    # Assumes all tasks in the past!
+    # Assumes all tasks in the past by more than a few days!
     filt_tasks = autils.get_filtered_tasks(sect_gid, False, None,
             rd_datetime_1m_ago)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]

--- a/tests/unit/asana/test_utils.py
+++ b/tests/unit/asana/test_utils.py
@@ -242,6 +242,19 @@ def test_get_filtered_tasks( # pylint: disable=too-many-locals, too-many-stateme
     filt_tasks = autils.get_filtered_tasks(sect_gid, False, rd_date_today,
             rd_date_today, assumed_time_1, dt_base=dt_base_1)
     tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
+    print('test tasks:')
+    print('-----------')
+    for task in tasks_with_due_in_utl_test:
+        print()
+        print(task)
+    print()
+    print()
+    print('tasks to check:')
+    print('---------------')
+    for task in tasks_to_check:
+        print()
+        print(task)
+    print()
     assert {created_task_gids[i] for i in [0, 3, 5, 6]} \
             == {t['gid'] for t in tasks_to_check}
 

--- a/tests/unit/asana/test_utils.py
+++ b/tests/unit/asana/test_utils.py
@@ -203,11 +203,16 @@ def test_get_filtered_tasks(sections_in_utl_test, tasks_with_due_in_utl_test):
     # Use same section gid as used in `tasks_with_due_in_utl_test`
     sect_gid = sections_in_utl_test[1]['gid']
     # Will be comparing task names only
-    task_names = [t['name'] for t in tasks_with_due_in_utl_test]
+    created_task_gids = [t['gid'] for t in tasks_with_due_in_utl_test]
 
     filt_tasks = autils.get_filtered_tasks(sect_gid, True)
-    assert {task_names[i] for i in [7]}.issubset(
-            [t['name'] for t in filt_tasks])
+    tasks_to_check = [t for t in filt_tasks if t['gid'] in created_task_gids]
+    assert {created_task_gids[i] for i in [7]} \
+            == {t['gid'] for t in tasks_to_check}
+    assert 'due_at' in tasks_to_check[0]
+    assert 'due_on' in tasks_to_check[0]
+    assert tasks_to_check[0]['name'] == tasks_with_due_in_utl_test[7]['name']
+    assert tasks_to_check[0]['resource_type'] == 'task'
 
 
 

--- a/tests/unit/asana/tester_data.py
+++ b/tests/unit/asana/tester_data.py
@@ -20,6 +20,11 @@ Module Attributes:
     needed for testing.  This will be created and deleted as needed during unit
     testing.
 
+  _TASK_TEMPLATE (Template): The name format to be used for test tasks created
+    in the test workspace for unit testing.  IDs will be substituted as needed
+    for testing.  This will be created and deleted as needed during unit
+    testing.
+
 (C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 from string import Template
@@ -31,3 +36,5 @@ _WORKSPACE = 'TEST Asana Extensions'
 _PROJECT_TEMPLATE = Template('TEST Project $pid')
 
 _SECTION_TEMPLATE = Template('TEST Section $sid')
+
+_TASK_TEMPLATE = Template('TEST Task $tid')

--- a/tests/unit/general/__init__.py
+++ b/tests/unit/general/__init__.py
@@ -2,4 +2,5 @@
 __all__ = [
         'test_config',
         'test_dirs',
+        'test_utils',
 ]

--- a/tests/unit/general/test_utils.py
+++ b/tests/unit/general/test_utils.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+Tests the asana_extensions.general.utils functionality.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import datetime as dt
+
+from dateutil.relativedelta import relativedelta
+import pytest
+
+from asana_extensions.general import utils
+
+
+
+def test_is_date_only():
+    """
+    Tests the `is_date_only()` method.
+    """
+    rd_date = relativedelta(days=1, months=2, years=3)
+    assert utils.is_date_only(rd_date) is True
+
+    rd_datetime = relativedelta(days=1, seconds=2)
+    assert utils.is_date_only(rd_datetime) is False
+
+    iso_date = '2021-01-01'
+    assert utils.is_date_only(iso_date) is True
+
+    iso_datetime = '2021-01-01 00:00'
+    assert utils.is_date_only(iso_datetime) is False
+
+    bad_str = 'this is only a date, trust me'
+    with pytest.raises(NotImplementedError) as ex:
+        utils.is_date_only(bad_str)
+    assert 'is not supported at this time:' in str(ex.value)
+
+    unsupported_dt_date = dt.date.today()
+    with pytest.raises(NotImplementedError) as ex:
+        utils.is_date_only(unsupported_dt_date)
+    assert 'is not supported at this time:' in str(ex.value)

--- a/tests/unit/rules/test_move_tasks_rule.py
+++ b/tests/unit/rules/test_move_tasks_rule.py
@@ -25,7 +25,7 @@ from asana_extensions.rules import rule_meta
 
 
 
-def test_load_specific_from_conf(caplog):
+def test_load_specific_from_conf(caplog):  # pylint: disable=too-many-statements
     """
     Tests the `load_specific_from_conf()` method in `MoveTasksRule`.
 
@@ -66,6 +66,17 @@ def test_load_specific_from_conf(caplog):
 
     caplog.clear()
     rule = move_tasks_rule.MoveTasksRule.load_specific_from_conf(rules_cp,
+            'test-move-tasks-full')
+    assert rule is None
+    assert caplog.record_tuples == [
+            ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
+                "Failed to create Move Tasks Rule from config:" \
+                    " Cannot specify 'for my tasks list' and" \
+                    + " 'user task list gid' together."),
+    ]
+
+    caplog.clear()
+    rule = move_tasks_rule.MoveTasksRule.load_specific_from_conf(rules_cp,
             'test-invalid-boolean')
     assert rule is None
     assert caplog.record_tuples == [
@@ -76,12 +87,12 @@ def test_load_specific_from_conf(caplog):
 
     caplog.clear()
     rule = move_tasks_rule.MoveTasksRule.load_specific_from_conf(rules_cp,
-            'test-move-tasks-full-is-utl-and-gid')
+            'test-move-tasks-is-utl-and-gid')
     assert rule is None
     assert caplog.record_tuples == [
             ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
                 "Failed to create Move Tasks Rule from config:" \
-                    " Cannot specify 'is my tasks list' and" \
+                    " Cannot specify 'for my tasks list' and" \
                     + " 'user task list gid' together."),
     ]
 
@@ -119,13 +130,25 @@ def test_load_specific_from_conf(caplog):
 
     caplog.clear()
     rule = move_tasks_rule.MoveTasksRule.load_specific_from_conf(rules_cp,
+                'test-move-tasks-timeframe-parse-fail')
+    assert rule is None
+    assert caplog.record_tuples == [
+            ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
+                "Failed to parse Move Tasks Rule from config.  Check timeframe"
+                + " args.  Exception: Could not parse time frame - Found 2"
+                + " entries for minutes?/m when only 0-1 allowed."),
+    ]
+
+    caplog.clear()
+    rule = move_tasks_rule.MoveTasksRule.load_specific_from_conf(rules_cp,
                 'test-move-tasks-time-parse-fail')
     assert rule is None
     assert caplog.record_tuples == [
             ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
                 "Failed to parse Move Tasks Rule from config.  Check time args."
-                + "  Exception: Could not parse time frame - Found 2 entries"
-                + " for minutes?/m when only 0-1 allowed."),
+                + "  Exception: Timezone prohibited for time string, but one was"
+                + " provided.  String: '12:23:45+00:00', parsed:"
+                + " `12:23:45+00:00`"),
     ]
 
     caplog.clear()

--- a/tests/unit/rules/test_move_tasks_rule/mock_move_tasks_rules.conf
+++ b/tests/unit/rules/test_move_tasks_rule/mock_move_tasks_rules.conf
@@ -9,12 +9,14 @@ project name : test project name
 workspace name : test workspace name
 min time until due : 1m
 max time until due : 2h
+assumed time for min due : 01:23
+assumed time for max due : 04:56
 src sections include names : test src section include name 1
         test src section include name 2
 src sections exclude names : test src section exclude name 1
 dst section name : test dst section name
 
-[test-move-tasks-full-is-utl-and-gid]
+[test-move-tasks-full]
 rule type : move tasks
 test report only : True
 project name : test project name
@@ -23,9 +25,11 @@ for my tasks list : True
 user task list id : -2
 workspace name : test workspace name
 workspace gid : -3
+no due date : True
 min time until due : 1m
 max time until due : 2h
-no due date : True
+assumed time for min due : 01:23
+assumed time for max due : 04:56
 src sections include names : test src section include name 1
         test src section include name 2
 src sections include gids : -4
@@ -38,6 +42,11 @@ dst section gid : -7
 [test-invalid-boolean]
 rule type : move tasks
 for my tasks list : 42
+
+[test-move-tasks-is-utl-and-gid]
+rule type : move tasks
+for my tasks list : True
+user task list id : -2
 
 [test-move-tasks-no-proj-no-utl]
 rule type : move tasks
@@ -54,21 +63,29 @@ rule type : move tasks
 test report only : True
 for my tasks list : True
 
-[test-move-tasks-time-parse-fail]
+[test-move-tasks-timeframe-parse-fail]
 rule type : move tasks
 test report only : True
 for my tasks list : True
 workspace name : test workspace name
 min time until due : 1m+1m
 
-[test-move-tasks-both-time-until-and-no-due]
+[test-move-tasks-time-parse-fail]
 rule type : move tasks
 test report only : True
 for my tasks list : True
 workspace name : test workspace name
 min time until due : 1m
-max time until due : 2h
+assumed time for min due : 12:23:45+00:00
+
+[test-move-tasks-both-time-until-and-no-due]
+rule type : move tasks
+test report only : True
+for my tasks list : True
+workspace name : test workspace name
 no due date : True
+min time until due : 1m
+max time until due : 2h
 
 [test-move-tasks-time-neither-time-until-nor-no-due]
 rule type : move tasks

--- a/tests/unit/rules/test_rule_meta.py
+++ b/tests/unit/rules/test_rule_meta.py
@@ -158,6 +158,9 @@ def test_parse_timedelta_arg():
             minutes=1, hours=2, days=3, weeks=4, months=-5, years=6)
 
     test_str = ''
+    assert rule_meta.Rule.parse_timedelta_arg(test_str) == None
+
+    test_str = '0d'
     assert rule_meta.Rule.parse_timedelta_arg(test_str) == relativedelta()
 
     test_str = '1h 2hours'

--- a/tests/unit/rules/test_rule_meta.py
+++ b/tests/unit/rules/test_rule_meta.py
@@ -158,7 +158,7 @@ def test_parse_timedelta_arg():
             minutes=1, hours=2, days=3, weeks=4, months=-5, years=6)
 
     test_str = ''
-    assert rule_meta.Rule.parse_timedelta_arg(test_str) == None
+    assert rule_meta.Rule.parse_timedelta_arg(test_str) is None
 
     test_str = '0d'
     assert rule_meta.Rule.parse_timedelta_arg(test_str) == relativedelta()

--- a/tests/unit/rules/test_rule_meta.py
+++ b/tests/unit/rules/test_rule_meta.py
@@ -14,6 +14,7 @@ Module Attributes:
 """
 #pylint: disable=protected-access  # Allow for purpose of testing those elements
 
+import datetime as dt
 import logging
 import os.path
 
@@ -142,6 +143,39 @@ def test_load_specific_from_conf(caplog):
     assert rule is not None
     assert rule._rule_params['rule_type'] == 'blank rule'
     assert caplog.record_tuples == []
+
+
+
+def test_parse_time_arg():
+    """
+    Tests the `parse_time_arg()` method in `Rule`.
+    """
+    test_str = '13:00'
+    test_time = dt.time.fromisoformat(test_str)
+    assert rule_meta.Rule.parse_time_arg(test_str) == test_time
+    assert rule_meta.Rule.parse_time_arg(test_str, None) == test_time
+    with pytest.raises(config.UnsupportedFormatError) as ex:
+        rule_meta.Rule.parse_time_arg(test_str, True)
+    assert 'Timezone required' in str(ex.value)
+
+    test_str = '13:00-05:00'
+    test_time = dt.time.fromisoformat(test_str)
+    assert rule_meta.Rule.parse_time_arg(test_str) == test_time
+    assert rule_meta.Rule.parse_time_arg(test_str, True) == test_time
+    with pytest.raises(config.UnsupportedFormatError) as ex:
+        rule_meta.Rule.parse_time_arg(test_str, None)
+    assert 'Timezone prohibited' in str(ex.value)
+
+    assert rule_meta.Rule.parse_time_arg(None) is None
+    assert rule_meta.Rule.parse_time_arg('', True) is None
+
+    with pytest.raises(AssertionError) as ex:
+        rule_meta.Rule.parse_time_arg('', 'invalid value')
+    assert '`is_tz_required` must be bool or None' in str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        rule_meta.Rule.parse_time_arg('bad time str')
+    assert 'Invalid isoformat string' in str(ex.value)
 
 
 


### PR DESCRIPTION
This adds the functionality to get tasks from the asana API and to filter them based on due date/time and completion status.  A few other tweaks needed to be made along the way on this adventure though...

- Added an `is_date_only()` checker.
- `assumed time for min/max due` added to `rules.conf` for `MoveTasksRule`, with notes on how to use it.
  - `parse_time_arg()` added to `Rule` to support parsing the new arg.
- An empty string for timeframe config arg now returns None rather than an empty `relativedelta()`.
- `fixture_sections_in_utl_test()` moved from `/tests/unit/asana/test_client.py` to new `/tests/unit/asana/conftest.py` so it can be used by multiple modules in that subpackage.
- `_TASK_TEMPLATE` added to `tester_date`.
- `/asana_extensions/general/utils.py` added, with corresponding unit test module.
- Some small tweaks to error messages.

...and so much more...

Closes #18.