### PR TITLE
feature/2-move-tasks-rule into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,10 +237,26 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Added] `rules.py` added with `load_all_from_config()` started to load all
       rules from the `rules.conf` file ([#1][]).
 - [Added] `MoveTasksRule` added to `_RULES` list in `rules.py` ([#1][]).
-- [Added] `parse_time_arg()` added to parse time-only iso-format values (not
-      full ISO 8601 format though) ([#18][]).
+- [Added] `parse_time_arg()` added to `Rule` to parse time-only iso-format
+      values (not full ISO 8601 format though) ([#18][]).
 - [Changed] `parse_timedelta_arg()` will now also return `None` if an empty
       string is provided in case key is left in config but is blank ([#18][]).
+- [Added] `_is_valid` added to `Rule` to store cached validation results
+      ([#2][]).
+- [Added] `get_rule_id()` accessor method added to `Rule` ([#2][]).
+- [Added] `_sync_and_validate_with_api()` and `_execute()` abstract methods
+      added to `Rule` ([#2][]).
+- [Added] `is_valid()` and `is_criteria_met()` methods added to `Rule` with
+      default logic for any subclasses that don't need to override ([#2][]).
+- [Added] `execute_rules()` added to `rules.py` to perform the actions for all
+      provided rules ([#2][]).
+
+##### Unit Tests: conftest
+- [Added] Added `conftest.py` to root of `rules` subpackage in unit tests dir,
+      with new `fixture_blank_rule_cls()` added for use by other modules
+      in subpackage ([#2][]).
+- [Changed] Some existing functions that used a `BlankRule` class refactored to
+      use `fixture_blank_rule_cls()` ([#2][]).
 
 
 ### Rules: Move Tasks Rule
@@ -252,12 +268,22 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Changed] References to timeframe in error messages changed to be `timeframe`
       instead of `time` to be more clear and distinuish from assumed time errors
       ([#18][]).
+- [Added] Implemented `_sync_and_validate_with_api()` to do API-dependent
+      pre-processing [#2][].
+- [Added] Implemented `execute()` to check and perform `MoveTasksRule` action
+      ([#2][]).
 
 ##### Unit Tests
 - [Changed] `[test-move-tasks-full-is-utl-and-gid]` is now split into
       `[test-move-tasks-is-utl-and-gid]` and `[test-move-tasks-full]` to ensure
       that if `full` is changed later, no need to worry about it reducing
       coverage ([#18][]).
+- [Added] `fixture_blank_move_tasks_rule()` added as a basis for a blank
+      `MoveTasksRule` ([#2][]).
+- [Changed] `test_load_specific_from_conf_impossible()` renamed to
+      `test_load_specific_from_conf__impossible()` ([#2][]).
+- [Changed] `test_get_provider_names()` renamed to `test_get_rule_type_names()`
+      ([#2][]).
 
 
 ### Docs: CHANGELOG
@@ -305,6 +331,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 
 #### Issues
 - [#1][]
+- [#2][]
 - [#5][]
 - [#7][]
 - [#9][]
@@ -333,6 +360,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#32][] for [#18][]
 - [#34][] for [#33][]
 - [#38][] for [#19][]
+- [#41][] for [#2][]
 
 
 ---
@@ -354,6 +382,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#18]: https://github.com/JonathanCasey/asana_extensions/issues/18 'Issue #18'
 [#33]: https://github.com/JonathanCasey/asana_extensions/issues/33 'Issue #33'
 [#19]: https://github.com/JonathanCasey/asana_extensions/issues/19 'Issue #19'
+[#2]: https://github.com/JonathanCasey/asana_extensions/issues/2 'Issue #2'
 
 [#6]: https://github.com/JonathanCasey/asana_extensions/pull/6 'PR #6'
 [#8]: https://github.com/JonathanCasey/asana_extensions/pull/8 'PR #8'
@@ -368,3 +397,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#32]: https://github.com/JonathanCasey/asana_extensions/pull/32 'PR #32'
 [#34]: https://github.com/JonathanCasey/asana_extensions/pull/34 'PR #34'
 [#38]: https://github.com/JonathanCasey/asana_extensions/pull/38 'PR #38'
+[#41]: https://github.com/JonathanCasey/asana_extensions/pull/41 'PR #41'

--- a/asana_extensions/rules/move_tasks_rule.py
+++ b/asana_extensions/rules/move_tasks_rule.py
@@ -10,6 +10,10 @@ Module Attributes:
 """
 import logging
 
+import asana
+
+from asana_extensions.asana import client as aclient
+from asana_extensions.asana import utils as autils
 from asana_extensions.general import config
 from asana_extensions.general.exceptions import *   # pylint: disable=wildcard-import
 from asana_extensions.rules import rule_meta
@@ -31,6 +35,8 @@ class MoveTasksRule(rule_meta.Rule):
     Instance Attributes:
       _rules_params ({str:str/int/bool/etc}): The generic dictionary that
         defines the parameters for this rule.
+      _is_valid (bool or None): Cached value as to whether the rule is valid.
+        If not validated yet, will be None.
 
       [inherited from Rule]:
         _rule_id (str): The id used as the section name in the rules conf.
@@ -78,6 +84,8 @@ class MoveTasksRule(rule_meta.Rule):
                 + " date (but not both)."
 
         self._rule_params = rule_params
+
+        self._is_valid = None
 
 
 
@@ -209,3 +217,132 @@ class MoveTasksRule(rule_meta.Rule):
         # pylint: disable=multi-line-list-eol-close, closing-comma
         return ['move tasks', 'auto-promote tasks', 'auto-promote',
                 'auto promote tasks', 'auto promote', 'promote tasks']
+
+
+
+    def _sync_and_validate_with_api(self):
+        """
+        Sync configuration data with the API and further validate, storing any
+        newly prepared configuration info.
+
+        Returns:
+          (bool): True if completed successfully; False if failed for any
+            reason (this should probably catch nearly all exceptions).
+        """
+        rps = self._rule_params # Shorten name since used so much here
+        try:
+            if rps['workspace_name'] is not None:
+                rps['workspace_gid'] = aclient.get_workspace_gid_from_name(
+                            rps['workspace_name'], rps['workspace_gid'])
+
+            if rps['is_my_tasks_list']:
+                rps['user_task_list_gid'] = aclient.get_user_task_list_gid(
+                        rps['workspace_gid'], True)
+
+            if rps['project_name'] is not None:
+                # For now, hardcoded for non-archived project
+                #   Could use None, but workaround for now is to specify by gid
+                rps['project_gid'] = aclient.get_project_gid_from_name(
+                        rps['workspace_gid'], rps['project_name'],
+                        rps['project_gid'])
+                rps['effective_project_gid'] = rps['project_gid']
+
+            elif rps['user_task_list_gid'] is not None:
+                rps['effective_project_gid'] = rps['user_task_list_gid']
+
+            # Else, shouldn't be possible based on assertions in __init__()
+
+            # Always want to default to include for move task rule
+            rps['src_net_include_section_gids'] = \
+                    autils.get_net_include_section_gids(
+                            rps['effective_project_gid'],
+                            rps['src_sections_include_names'],
+                            rps['src_sections_include_gids'],
+                            rps['src_sections_exclude_names'],
+                            rps['src_sections_exclude_gids'])
+
+            if rps['dst_section_name'] is not None:
+                rps['dst_section_gid'] = aclient.get_section_gid_from_name(
+                        rps['effective_project_gid'], rps['dst_section_name'],
+                        rps['dst_section_gid'])
+
+        except (asana.error.AsanaError, aclient.ClientCreationError,
+                aclient.DataNotFoundError, aclient.DuplicateNameError,
+                aclient.MismatchedDataError, autils.DataConflictError,
+                autils.DataMissingError):
+            return False
+
+        return True
+
+
+
+    def is_valid(self):
+        """
+        Check whether this rule is valid or not.  This ideally utilizes a cached
+        value so that the check for being valid does not need to be done more
+        than once since that could involve heavy API access.  As a result, it is
+        likely that this should call `_sync_and_validate_with_api()`.
+
+        Returns:
+          (bool): True if is valid; False if invalid.
+        """
+        if self._is_valid is None:
+            self._is_valid = self._sync_and_validate_with_api()
+        return self._is_valid
+
+
+
+    def is_criteria_met(self):
+        """
+        Checks whether the criteria to run this rule, if any, has been met.  If
+        any additional processing is required for this, it should be done and
+        stored as appropriate.  In such a case, it may be advisable to cache
+        the overall result.
+
+        Where possible, this should be decoupled from `is_valid()`, but in many
+        cases it will likely make sense for this to only run if `is_valid()` is
+        True.  Hence, this may get masked by that result in those cases.
+
+        Some rules do not have any specific criteria as to whether the rule
+        should run (e.g. no specific datetime at which it should run if script
+        expected to be called multiple times), in which case this should just
+        return True.
+
+        Returns:
+          (bool): True if criteria is met for rule to run or there is no
+            criteria (i.e. this is not applicable); False if not ready to run.
+        """
+        # No offline criteria other than validity check
+        return True
+
+
+
+    def execute(self, force_test_report_only=False):
+        """
+        Execute the rule.  This should likely check if it is valid and the
+        criteria to run the rule has been met (if any).  If either the rule is
+        set to test report only or the caller of this method specified to force
+        to be test report only, no changes will be made via the API -- only
+        simulated results will be reported (but still based on data from API).
+
+        Args:
+          force_test_report_only (bool): If True, will ensure this runs as a
+            test report only with no changes made via the API; if False, will
+            defer to the `_test_report_only` setting of the rule.
+        """
+        if not self.is_valid() or not self.is_criteria_met():
+            return
+
+        rps = self._rule_params # Shorten name since used so much here
+        tasks_to_move = []
+        for src_sect_gid in rps['src_net_include_section_gids']:
+            # Could lock in a dt_base before loop, but likely not an issue
+            # For now, hardcoded for incomplete tasks
+            tasks_to_move.extend(autils.get_filtered_tasks(src_sect_gid,
+                    rps['match_no_due_date'],
+                    rps['min_time_until_due'], rps['max_time_until_due'],
+                    rps['min_due_assumed_time'], rps['max_due_assumed_time']))
+
+        for task in tasks_to_move[::-1]:
+            # For now, hardcoded to move to top, maintaining order
+            aclient.move_task_to_section(task['gid'], rps['dst_section_gid'])

--- a/asana_extensions/rules/move_tasks_rule.py
+++ b/asana_extensions/rules/move_tasks_rule.py
@@ -35,14 +35,14 @@ class MoveTasksRule(rule_meta.Rule):
     Instance Attributes:
       _rules_params ({str:str/int/bool/etc}): The generic dictionary that
         defines the parameters for this rule.
-      _is_valid (bool or None): Cached value as to whether the rule is valid.
-        If not validated yet, will be None.
 
       [inherited from Rule]:
         _rule_id (str): The id used as the section name in the rules conf.
         _rule_type (str): The type of rule, such as "move tasks".
         _test_report_only (bool): Whether or not this is for reporting for
           testing only or whether rule is live.
+        _is_valid (bool or None): Cached value as to whether the rule is valid.
+          If not validated yet, will be None.
     """
     def __init__(self, rule_params, **kwargs):
         """
@@ -84,8 +84,6 @@ class MoveTasksRule(rule_meta.Rule):
                 + " date (but not both)."
 
         self._rule_params = rule_params
-
-        self._is_valid = None
 
 
 
@@ -272,47 +270,6 @@ class MoveTasksRule(rule_meta.Rule):
                 autils.DataMissingError):
             return False
 
-        return True
-
-
-
-    def is_valid(self):
-        """
-        Check whether this rule is valid or not.  This ideally utilizes a cached
-        value so that the check for being valid does not need to be done more
-        than once since that could involve heavy API access.  As a result, it is
-        likely that this should call `_sync_and_validate_with_api()`.
-
-        Returns:
-          (bool): True if is valid; False if invalid.
-        """
-        if self._is_valid is None:
-            self._is_valid = self._sync_and_validate_with_api()
-        return self._is_valid
-
-
-
-    def is_criteria_met(self):
-        """
-        Checks whether the criteria to run this rule, if any, has been met.  If
-        any additional processing is required for this, it should be done and
-        stored as appropriate.  In such a case, it may be advisable to cache
-        the overall result.
-
-        Where possible, this should be decoupled from `is_valid()`, but in many
-        cases it will likely make sense for this to only run if `is_valid()` is
-        True.  Hence, this may get masked by that result in those cases.
-
-        Some rules do not have any specific criteria as to whether the rule
-        should run (e.g. no specific datetime at which it should run if script
-        expected to be called multiple times), in which case this should just
-        return True.
-
-        Returns:
-          (bool): True if criteria is met for rule to run or there is no
-            criteria (i.e. this is not applicable); False if not ready to run.
-        """
-        # No offline criteria other than validity check
         return True
 
 

--- a/asana_extensions/rules/move_tasks_rule.py
+++ b/asana_extensions/rules/move_tasks_rule.py
@@ -335,9 +335,16 @@ class MoveTasksRule(rule_meta.Rule):
                 try:
                     aclient.move_task_to_section(task['gid'],
                             rps['dst_section_gid'])
+                    msg = f'Successfully moved task "{task["name"]}"'
+                    msg += f' [{task["gid"]}] to section'
+                    if rps['dst_section_name'] is not None:
+                        msg += f' "{rps["dst_section_name"]}"'
+                    msg += f' [{rps["dst_section_gid"]}] per "{self._rule_id}".'
+                    logger.info(msg)
                 except (asana.error.AsanaError,
                         aclient.ClientCreationError) as ex:
-                    msg = f'Failed to move task {task["gid"]} to section'
+                    msg = f'Failed to move task "{task["name"]}"'
+                    msg += f' [{task["gid"]}] to section'
                     if rps['dst_section_name'] is not None:
                         msg += f' "{rps["dst_section_name"]}"'
                     msg += f' [{rps["dst_section_gid"]}] for "{self._rule_id}".'

--- a/asana_extensions/rules/move_tasks_rule.py
+++ b/asana_extensions/rules/move_tasks_rule.py
@@ -233,21 +233,21 @@ class MoveTasksRule(rule_meta.Rule):
                 rps['workspace_gid'] = aclient.get_workspace_gid_from_name(
                             rps['workspace_name'], rps['workspace_gid'])
 
-            if rps['is_my_tasks_list']:
-                rps['user_task_list_gid'] = aclient.get_user_task_list_gid(
-                        rps['workspace_gid'], True)
-
             if rps['project_name'] is not None:
                 # For now, hardcoded for non-archived project
                 #   Could use None, but workaround for now is to specify by gid
                 rps['project_gid'] = aclient.get_project_gid_from_name(
                         rps['workspace_gid'], rps['project_name'],
                         rps['project_gid'])
-                rps['effective_project_gid'] = rps['project_gid']
 
+            if rps['is_my_tasks_list']:
+                rps['user_task_list_gid'] = aclient.get_user_task_list_gid(
+                        rps['workspace_gid'], True)
+
+            if rps['project_gid'] is not None:
+                rps['effective_project_gid'] = rps['project_gid']
             elif rps['user_task_list_gid'] is not None:
                 rps['effective_project_gid'] = rps['user_task_list_gid']
-
             # Else, shouldn't be possible based on assertions in __init__()
 
             # Always want to default to include for move task rule

--- a/asana_extensions/rules/rule_meta.py
+++ b/asana_extensions/rules/rule_meta.py
@@ -131,6 +131,76 @@ class Rule(ABC):
 
 
 
+    @abstractmethod
+    def _sync_and_validate_with_api(self):
+        """
+        Sync configuration data with the API and further validate, storing any
+        newly prepared configuration info.  This is largely a contintuation
+        of __init__() where API-dependent items can be completed in case it is
+        ideal to decouple the API access from __init__().
+
+        Returns:
+          (bool): True if completed successfully; False if failed for any
+            reason (this should probably catch nearly all exceptions).
+        """
+
+
+
+    @abstractmethod
+    def is_valid(self):
+        """
+        Check whether this rule is valid or not.  This ideally utilizes a cached
+        value so that the check for being valid does not need to be done more
+        than once since that could involve heavy API access.  As a result, it is
+        likely that this should call `_sync_and_validate_with_api()`.
+
+        Returns:
+          (bool): True if is valid; False if invalid.
+        """
+
+
+
+    @abstractmethod
+    def is_criteria_met(self):
+        """
+        Checks whether the criteria to run this rule, if any, has been met.  If
+        any additional processing is required for this, it should be done and
+        stored as appropriate.  In such a case, it may be advisable to cache
+        the overall result.
+
+        Where possible, this should be decoupled from `is_valid()`, but in many
+        cases it will likely make sense for this to only run if `is_valid()` is
+        True.  Hence, this may get masked by that result in those cases.
+
+        Some rules do not have any specific criteria as to whether the rule
+        should run (e.g. no specific datetime at which it should run if script
+        expected to be called multiple times), in which case this should just
+        return True.
+
+        Returns:
+          (bool): True if criteria is met for rule to run or there is no
+            criteria (i.e. this is not applicable); False if not ready to run.
+        """
+
+
+
+    @abstractmethod
+    def execute(self, force_test_report_only=False):
+        """
+        Execute the rule.  This should likely check if it is valid and the
+        criteria to run the rule has been met (if any).  If either the rule is
+        set to test report only or the caller of this method specified to force
+        to be test report only, no changes will be made via the API -- only
+        simulated results will be reported (but still based on data from API).
+
+        Args:
+          force_test_report_only (bool): If True, will ensure this runs as a
+            test report only with no changes made via the API; if False, will
+            defer to the `_test_report_only` setting of the rule.
+        """
+
+
+
     @classmethod
     def parse_time_arg(cls, t_str, is_tz_required=False):
         """

--- a/asana_extensions/rules/rule_meta.py
+++ b/asana_extensions/rules/rule_meta.py
@@ -207,6 +207,10 @@ class Rule(ABC):
           force_test_report_only (bool): If True, will ensure this runs as a
             test report only with no changes made via the API; if False, will
             defer to the `_test_report_only` setting of the rule.
+
+        Returns:
+          (bool): True if fully completed without any errors; False any errors,
+            regardless of whether it resulted in partial or full failure.
         """
 
 

--- a/asana_extensions/rules/rule_meta.py
+++ b/asana_extensions/rules/rule_meta.py
@@ -178,7 +178,7 @@ class Rule(ABC):
 
 
 
-    def is_criteria_met(self):
+    def is_criteria_met(self):                     # pylint: disable=no-self-use
         """
         Checks whether the criteria to run this rule, if any, has been met.  If
         any additional processing is required for this, it should be done and

--- a/asana_extensions/rules/rule_meta.py
+++ b/asana_extensions/rules/rule_meta.py
@@ -121,6 +121,17 @@ class Rule(ABC):
 
 
 
+    def get_rule_id(self):
+        """
+        Get the id/name of this rule.
+
+        Returns:
+          _rule_id (str): The ID or name of this rule.
+        """
+        return self._rule_id
+
+
+
     @classmethod
     @abstractmethod
     def get_rule_type_names(cls):

--- a/asana_extensions/rules/rules.py
+++ b/asana_extensions/rules/rules.py
@@ -80,5 +80,7 @@ def execute_rules(rules, force_test_report_only=False):
     """
     any_errors = False
     for rule in rules:
-        any_errors = rule.execute(force_test_report_only) or any_errors
+        if not rule.execute(force_test_report_only):
+            logger.error(f'Failure in fully executing "{rule.get_rule_id()}".')
+            any_errors = True
     return not any_errors

--- a/asana_extensions/rules/rules.py
+++ b/asana_extensions/rules/rules.py
@@ -59,3 +59,20 @@ def load_all_from_config(conf_rel_file='rules.conf'):
             loaded_rules.append(new_rule)
 
     return loaded_rules
+
+
+
+def execute_rules(rules, force_test_report_only=False):
+    """
+    Execute all provided rules.  If either an individual rule is set to test
+    report only or the caller of this method specified to force to be test
+    report only, no changes will be made via the API for that rule -- only
+    simulated results will be reported (but still based on data from API).
+
+    Args:
+      force_test_report_only (bool): If True, will ensure this runs as a test
+        report only with no changes made via the API for all rules; if False,
+        will defer to the `_test_report_only` setting of each rule.
+    """
+    for rule in rules:
+        rule.execute(force_test_report_only)

--- a/asana_extensions/rules/rules.py
+++ b/asana_extensions/rules/rules.py
@@ -73,6 +73,12 @@ def execute_rules(rules, force_test_report_only=False):
       force_test_report_only (bool): If True, will ensure this runs as a test
         report only with no changes made via the API for all rules; if False,
         will defer to the `_test_report_only` setting of each rule.
+
+    Returns:
+      (bool): True if fully completed without any errors; False any errors,
+        regardless of whether it resulted in partial or full failure.
     """
+    any_errors = False
     for rule in rules:
-        rule.execute(force_test_report_only)
+        any_errors = rule.execute(force_test_report_only) or any_errors
+    return not any_errors

--- a/tests/unit/rules/__init__.py
+++ b/tests/unit/rules/__init__.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
+        'conftest',
         'test_move_tasks_rule',
         'test_rule_meta',
         'test_rules',

--- a/tests/unit/rules/conftest.py
+++ b/tests/unit/rules/conftest.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Configures pytest as needed.  This file normally does not need to exist, but is
+used here to share and configure items for the /tests/unit/rules subpackage.
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import pytest
+
+from asana_extensions.rules import rule_meta
+
+
+
+@pytest.fixture(name='blank_rule_cls')
+def fixture_blank_rule_cls():
+    """
+    Returns a blank rule with default returns for all abstract methods.  This
+    can be used as is in most cases; in most other cases, this can serve as a
+    base with tests only needing to override individual methods via monkeypatch.
+    """
+    class BlankRule(rule_meta.Rule):
+        """
+        Simple blank rule to subclass Rule.
+        """
+        @classmethod
+        def load_specific_from_conf(cls, rules_cp, rule_id, rule_params=None,
+                **kwargs):
+            """
+            Not needed / will not be used.
+            """
+            return
+
+        @classmethod
+        def get_rule_type_names(cls):
+            """
+            Not needed / will not be used.
+            """
+            return []
+
+        def _sync_and_validate_with_api(self):
+            """
+            Not needed / will not be used.
+            """
+            return True
+
+        def execute(self, force_test_report_only=False):
+            """
+            Not needed / will not be used.
+            """
+            return True
+
+    return BlankRule

--- a/tests/unit/rules/test_move_tasks_rule.py
+++ b/tests/unit/rules/test_move_tasks_rule.py
@@ -22,6 +22,39 @@ import pytest
 from asana_extensions.general import config
 from asana_extensions.rules import move_tasks_rule
 from asana_extensions.rules import rule_meta
+from tests.unit.rules import test_rule_meta
+
+
+
+@pytest.fixture(name='blank_move_tasks_rule')
+def fixture_blank_move_tasks_rule():
+    """
+    Returns a blank move tasks rule that does the absolute bare minimum to be
+    initialized (though may add some extra if it helps cover more tests easily).
+
+    Tests using this could always "hack" in more _rule_params if the test knows
+    what it is doing.
+    """
+    kwargs = {
+        'rule_id': 'blank rule id',
+        'rule_type': 'move tasks',
+        'test_report_only': True,
+    }
+    # At very least, need to define all keys in `__init__()` and pass asserts
+    rule_params = {
+        'project_name': None,
+        'project_gid': -1,
+        'is_my_tasks_list': None,
+        'user_task_list_gid': None,
+        'workspace_name': None,
+        'workspace_gid': -2,
+        'min_time_until_due_str': None,
+        'max_time_until_due_str': None,
+        'min_time_until_due': None,
+        'max_time_until_due': None,
+        'match_no_due_date': True,
+    }
+    return move_tasks_rule.MoveTasksRule(rule_params, **kwargs)
 
 
 
@@ -246,3 +279,33 @@ def test_get_rule_type_names():
             in move_tasks_rule.MoveTasksRule.get_rule_type_names()
     assert 'not move tasks' \
             not in move_tasks_rule.MoveTasksRule.get_rule_type_names()
+
+
+
+def test_is_valid(monkeypatch, blank_move_tasks_rule):
+    """
+    Tests the `is_valid()` method in `MoveTasksRule`.
+
+    This is inherited from `Rule` and not overridden, but since it is expected
+    that it could be overridden, should be tested.
+    """
+    def mock__sync_and_validate_with_api():
+        """
+        Force to return True.
+        """
+        return True
+
+    monkeypatch.setattr(blank_move_tasks_rule, '_sync_and_validate_with_api',
+            mock__sync_and_validate_with_api)
+    test_rule_meta.subtest_is_valid(monkeypatch, blank_move_tasks_rule)
+
+
+
+def test_is_criteria_met(blank_move_tasks_rule):
+    """
+    Tests the `is_criteria_met()` method in `MoveTasksRule`.
+
+    This is inherited from `Rule` and not overridden, but since it is expected
+    that it could be overridden, should be tested.
+    """
+    test_rule_meta.subtest_is_criteria_met(blank_move_tasks_rule)

--- a/tests/unit/rules/test_move_tasks_rule.py
+++ b/tests/unit/rules/test_move_tasks_rule.py
@@ -423,6 +423,9 @@ def test__sync_and_validate_with_api(      # pylint: disable=too-many-statements
     assert bmtr._rule_params['src_net_include_section_gids'] == [-105, -106]
     assert bmtr._rule_params['dst_section_gid'] == -3
 
+    msg_base_err  = 'Failed to sync and validate rule "blank rule id" with the'
+    msg_base_err += ' API.  Skipping rule.  Exception:'
+
     caplog.clear()
     reset_rule_params()
     error = 'raise-client-creation-error'
@@ -430,8 +433,7 @@ def test__sync_and_validate_with_api(      # pylint: disable=too-many-statements
     assert bmtr._sync_and_validate_with_api() is False
     assert caplog.record_tuples == [
         ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
-            'Failed to sync and validate rule "blank rule id" with the API.'
-            + f'  Skipping rule.  Exception: {error}'),
+            f'{msg_base_err} {error}'),
     ]
 
     caplog.clear()
@@ -443,8 +445,7 @@ def test__sync_and_validate_with_api(      # pylint: disable=too-many-statements
     assert bmtr._sync_and_validate_with_api() is False
     assert caplog.record_tuples == [
         ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
-            'Failed to sync and validate rule "blank rule id" with the API.'
-            + '  Skipping rule.  Exception: Invalid Request'),
+            f'{msg_base_err} Invalid Request'),
     ]
 
     caplog.clear()
@@ -455,8 +456,7 @@ def test__sync_and_validate_with_api(      # pylint: disable=too-many-statements
     assert bmtr._sync_and_validate_with_api() is False
     assert caplog.record_tuples == [
         ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
-            'Failed to sync and validate rule "blank rule id" with the API.'
-            + f'  Skipping rule.  Exception: {error}'),
+            f'{msg_base_err} {error}'),
     ]
 
     caplog.clear()
@@ -466,8 +466,7 @@ def test__sync_and_validate_with_api(      # pylint: disable=too-many-statements
     assert bmtr._sync_and_validate_with_api() is False
     assert caplog.record_tuples == [
         ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
-            'Failed to sync and validate rule "blank rule id" with the API.'
-            + f'  Skipping rule.  Exception: {error}'),
+            f'{msg_base_err} {error}'),
     ]
 
     caplog.clear()
@@ -477,8 +476,7 @@ def test__sync_and_validate_with_api(      # pylint: disable=too-many-statements
     assert bmtr._sync_and_validate_with_api() is False
     assert caplog.record_tuples == [
         ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
-            'Failed to sync and validate rule "blank rule id" with the API.'
-            + f'  Skipping rule.  Exception: {error}'),
+            f'{msg_base_err} {error}'),
     ]
 
     caplog.clear()
@@ -489,8 +487,7 @@ def test__sync_and_validate_with_api(      # pylint: disable=too-many-statements
     assert bmtr._sync_and_validate_with_api() is False
     assert caplog.record_tuples == [
         ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
-            'Failed to sync and validate rule "blank rule id" with the API.'
-            + f'  Skipping rule.  Exception: {error}'),
+            f'{msg_base_err} {error}'),
     ]
 
     caplog.clear()
@@ -501,8 +498,7 @@ def test__sync_and_validate_with_api(      # pylint: disable=too-many-statements
     assert bmtr._sync_and_validate_with_api() is False
     assert caplog.record_tuples == [
         ('asana_extensions.rules.move_tasks_rule', logging.ERROR,
-            'Failed to sync and validate rule "blank rule id" with the API.'
-            + f'  Skipping rule.  Exception: {error}'),
+            f'{msg_base_err} {error}'),
     ]
 
 

--- a/tests/unit/rules/test_move_tasks_rule.py
+++ b/tests/unit/rules/test_move_tasks_rule.py
@@ -175,7 +175,7 @@ def test_load_specific_from_conf(caplog):  # pylint: disable=too-many-statements
 
 
 
-def test_load_specific_from_conf_impossible(monkeypatch, caplog):
+def test_load_specific_from_conf__impossible(monkeypatch, caplog):
     """
     Tests "impossible" cases in the `load_specific_from_conf()` method in
     `MoveTasksRule`.  These require mocking, as normally these are not possible
@@ -230,9 +230,9 @@ def test_load_specific_from_conf_impossible(monkeypatch, caplog):
 
 
 
-def test_get_provider_names():
+def test_get_rule_type_names():
     """
-    Tests the `get_provider_names()` method in `MoveTasksRule`.  Not an
+    Tests the `get_rule_type_names()` method in `MoveTasksRule`.  Not an
     exhaustive test.
     """
     assert 'move tasks' in move_tasks_rule.MoveTasksRule.get_rule_type_names()

--- a/tests/unit/rules/test_rule_meta.py
+++ b/tests/unit/rules/test_rule_meta.py
@@ -182,9 +182,10 @@ def test_load_specific_from_conf(caplog):
 
 
 
-def test_is_valid(monkeypatch, blank_rule_cls):
+def subtest_is_valid(monkeypatch, rule_test):
     """
-    Tests the `is_valid()` method in `Rule`.
+    Steps to test the `is_valid()` method in `Rule` and any of its subclasses
+    that do not override this non-abstract method.
     """
     def mock__sync_and_validate_with_api():
         """
@@ -192,20 +193,37 @@ def test_is_valid(monkeypatch, blank_rule_cls):
         """
         return False
 
-    blank_rule = blank_rule_cls('blank-rule-id', 'blank-rule-type', True)
-    assert blank_rule._is_valid is None
+    assert rule_test._is_valid is None
 
-    assert blank_rule.is_valid() is True
-    assert blank_rule._is_valid is True
+    assert rule_test.is_valid() is True
+    assert rule_test._is_valid is True
 
-    monkeypatch.setattr(blank_rule, '_sync_and_validate_with_api',
+    monkeypatch.setattr(rule_test, '_sync_and_validate_with_api',
             mock__sync_and_validate_with_api)
-    assert blank_rule.is_valid() is True
-    assert blank_rule._is_valid is True
+    assert rule_test.is_valid() is True
+    assert rule_test._is_valid is True
 
-    blank_rule._is_valid = None
-    assert blank_rule.is_valid() is False
-    assert blank_rule._is_valid is False
+    rule_test._is_valid = None
+    assert rule_test.is_valid() is False
+    assert rule_test._is_valid is False
+
+
+
+def test_is_valid(monkeypatch, blank_rule_cls):
+    """
+    Tests the `is_valid()` method in `Rule`.
+    """
+    blank_rule = blank_rule_cls('blank-rule-id', 'blank-rule-type', True)
+    subtest_is_valid(monkeypatch, blank_rule)
+
+
+
+def subtest_is_criteria_met(rule_test):
+    """
+    Steps to test the `is_criteria_met()` method in `Rule` and any of its
+    subclasses that do not override this non-abstract method.
+    """
+    assert rule_test.is_criteria_met() is True
 
 
 
@@ -214,7 +232,7 @@ def test_is_criteria_met(blank_rule_cls):
     Tests the `is_criteria_met()` method in `Rule`.
     """
     blank_rule = blank_rule_cls('blank-rule-id', 'blank-rule-type', True)
-    assert blank_rule.is_criteria_met() is True
+    subtest_is_criteria_met(blank_rule)
 
 
 

--- a/tests/unit/rules/test_rule_meta.py
+++ b/tests/unit/rules/test_rule_meta.py
@@ -27,48 +27,6 @@ from asana_extensions.rules import rule_meta
 
 
 
-@pytest.fixture(name='blank_rule_cls')
-def fixture_blank_rule_cls():
-    """
-    Returns a blank rule with default returns for all abstract methods.  This
-    can be used as is in most cases; in most other cases, this can serve as a
-    base with tests only needing to override individual methods via monkeypatch.
-    """
-    class BlankRule(rule_meta.Rule):
-        """
-        Simple blank rule to subclass Rule.
-        """
-        @classmethod
-        def load_specific_from_conf(cls, rules_cp, rule_id, rule_params=None,
-                **kwargs):
-            """
-            Not needed / will not be used.
-            """
-            return
-
-        @classmethod
-        def get_rule_type_names(cls):
-            """
-            Not needed / will not be used.
-            """
-            return []
-
-        def _sync_and_validate_with_api(self):
-            """
-            Not needed / will not be used.
-            """
-            return True
-
-        def execute(self, force_test_report_only=False):
-            """
-            Not needed / will not be used.
-            """
-            return True
-
-    return BlankRule
-
-
-
 def test_init(caplog, blank_rule_cls):
     """
     Tests `__init__()` method in `Rule`.

--- a/tests/unit/rules/test_rule_meta.py
+++ b/tests/unit/rules/test_rule_meta.py
@@ -172,6 +172,105 @@ def test_load_specific_from_conf(caplog):
 
 
 
+def test_is_valid(monkeypatch):
+    """
+    Tests the `is_valid()` method in `Rule`.
+    """
+
+    class BlankRule(rule_meta.Rule):
+        """
+        Simple blank rule to subclass Rule.
+        """
+        @classmethod
+        def load_specific_from_conf(cls, rules_cp, rule_id, rule_params=None,
+                **kwargs):
+            """
+            Not needed / will not be used.
+            """
+            return
+
+        @classmethod
+        def get_rule_type_names(cls):
+            """
+            Not needed / will not be used.
+            """
+            return []
+
+        def _sync_and_validate_with_api(self):
+            """
+            Not needed / will not be used.
+            """
+            return True
+
+        def execute(self, force_test_report_only=False):
+            """
+            Not needed / will not be used.
+            """
+            return
+
+    def mock__sync_and_validate_with_api():
+        """
+        Force to return False.
+        """
+        return False
+
+    blank_rule = BlankRule('blank-rule-id', 'blank-rule-type', True)
+    assert blank_rule._is_valid is None
+
+    assert blank_rule.is_valid() is True
+    assert blank_rule._is_valid is True
+
+    monkeypatch.setattr(blank_rule, '_sync_and_validate_with_api',
+            mock__sync_and_validate_with_api)
+    assert blank_rule.is_valid() is True
+    assert blank_rule._is_valid is True
+
+    blank_rule._is_valid = None
+    assert blank_rule.is_valid() is False
+    assert blank_rule._is_valid is False
+
+
+
+def test_is_criteria_met():
+    """
+    Tests the `is_criteria_met()` method in `Rule`.
+    """
+    class BlankRule(rule_meta.Rule):
+        """
+        Simple blank rule to subclass Rule.
+        """
+        @classmethod
+        def load_specific_from_conf(cls, rules_cp, rule_id, rule_params=None,
+                **kwargs):
+            """
+            Not needed / will not be used.
+            """
+            return
+
+        @classmethod
+        def get_rule_type_names(cls):
+            """
+            Not needed / will not be used.
+            """
+            return []
+
+        def _sync_and_validate_with_api(self):
+            """
+            Not needed / will not be used.
+            """
+            return True
+
+        def execute(self, force_test_report_only=False):
+            """
+            Not needed / will not be used.
+            """
+            return
+
+    blank_rule = BlankRule('blank-rule-id', 'blank-rule-type', True)
+    assert blank_rule.is_criteria_met() is True
+
+
+
 def test_parse_time_arg():
     """
     Tests the `parse_time_arg()` method in `Rule`.

--- a/tests/unit/rules/test_rule_meta.py
+++ b/tests/unit/rules/test_rule_meta.py
@@ -182,6 +182,15 @@ def test_load_specific_from_conf(caplog):
 
 
 
+def test_get_rule_id(blank_rule_cls):
+    """
+    Tests the `get_rule_id()` method in `Rule`.
+    """
+    blank_rule = blank_rule_cls('blank-rule-id', 'blank-rule-type', True)
+    assert blank_rule.get_rule_id() == 'blank-rule-id'
+
+
+
 def subtest_is_valid(monkeypatch, rule_test):
     """
     Steps to test the `is_valid()` method in `Rule` and any of its subclasses

--- a/tests/unit/rules/test_rule_meta.py
+++ b/tests/unit/rules/test_rule_meta.py
@@ -63,7 +63,7 @@ def fixture_blank_rule_cls():
             """
             Not needed / will not be used.
             """
-            return
+            return True
 
     return BlankRule
 
@@ -140,7 +140,7 @@ def test_load_specific_from_conf(caplog):
             """
             Not needed / will not be used.
             """
-            return
+            return True
 
     this_dir = os.path.dirname(os.path.realpath(__file__))
     conf_dir = os.path.join(this_dir, 'test_rule_meta')

--- a/tests/unit/rules/test_rule_meta.py
+++ b/tests/unit/rules/test_rule_meta.py
@@ -27,11 +27,13 @@ from asana_extensions.rules import rule_meta
 
 
 
-def test_init(caplog):
+@pytest.fixture(name='blank_rule_cls')
+def fixture_blank_rule_cls():
     """
-    Tests `__init__()` method in `Rule`.
+    Returns a blank rule with default returns for all abstract methods.  This
+    can be used as is in most cases; in most other cases, this can serve as a
+    base with tests only needing to override individual methods via monkeypatch.
     """
-
     class BlankRule(rule_meta.Rule):
         """
         Simple blank rule to subclass Rule.
@@ -63,17 +65,25 @@ def test_init(caplog):
             """
             return
 
+    return BlankRule
+
+
+
+def test_init(caplog, blank_rule_cls):
+    """
+    Tests `__init__()` method in `Rule`.
+    """
     caplog.set_level(logging.WARNING)
     caplog.clear()
 
-    blank_rule = BlankRule('blank-rule-id', 'blank-rule-type', True)
+    blank_rule = blank_rule_cls('blank-rule-id', 'blank-rule-type', True)
     assert blank_rule._rule_id == 'blank-rule-id'
     assert blank_rule._rule_type == 'blank-rule-type'
     assert blank_rule._test_report_only is True
     assert blank_rule._is_valid is None
     assert caplog.record_tuples == []
 
-    blank_extra_rule = BlankRule('blank-rule-id', 'blank-rule-type', True,
+    blank_extra_rule = blank_rule_cls('blank-rule-id', 'blank-rule-type', True,
             extras='extra-kwarg')
     assert blank_extra_rule._rule_id == 'blank-rule-id'
     assert blank_extra_rule._rule_type == 'blank-rule-type'
@@ -172,49 +182,17 @@ def test_load_specific_from_conf(caplog):
 
 
 
-def test_is_valid(monkeypatch):
+def test_is_valid(monkeypatch, blank_rule_cls):
     """
     Tests the `is_valid()` method in `Rule`.
     """
-
-    class BlankRule(rule_meta.Rule):
-        """
-        Simple blank rule to subclass Rule.
-        """
-        @classmethod
-        def load_specific_from_conf(cls, rules_cp, rule_id, rule_params=None,
-                **kwargs):
-            """
-            Not needed / will not be used.
-            """
-            return
-
-        @classmethod
-        def get_rule_type_names(cls):
-            """
-            Not needed / will not be used.
-            """
-            return []
-
-        def _sync_and_validate_with_api(self):
-            """
-            Not needed / will not be used.
-            """
-            return True
-
-        def execute(self, force_test_report_only=False):
-            """
-            Not needed / will not be used.
-            """
-            return
-
     def mock__sync_and_validate_with_api():
         """
         Force to return False.
         """
         return False
 
-    blank_rule = BlankRule('blank-rule-id', 'blank-rule-type', True)
+    blank_rule = blank_rule_cls('blank-rule-id', 'blank-rule-type', True)
     assert blank_rule._is_valid is None
 
     assert blank_rule.is_valid() is True
@@ -231,42 +209,11 @@ def test_is_valid(monkeypatch):
 
 
 
-def test_is_criteria_met():
+def test_is_criteria_met(blank_rule_cls):
     """
     Tests the `is_criteria_met()` method in `Rule`.
     """
-    class BlankRule(rule_meta.Rule):
-        """
-        Simple blank rule to subclass Rule.
-        """
-        @classmethod
-        def load_specific_from_conf(cls, rules_cp, rule_id, rule_params=None,
-                **kwargs):
-            """
-            Not needed / will not be used.
-            """
-            return
-
-        @classmethod
-        def get_rule_type_names(cls):
-            """
-            Not needed / will not be used.
-            """
-            return []
-
-        def _sync_and_validate_with_api(self):
-            """
-            Not needed / will not be used.
-            """
-            return True
-
-        def execute(self, force_test_report_only=False):
-            """
-            Not needed / will not be used.
-            """
-            return
-
-    blank_rule = BlankRule('blank-rule-id', 'blank-rule-type', True)
+    blank_rule = blank_rule_cls('blank-rule-id', 'blank-rule-type', True)
     assert blank_rule.is_criteria_met() is True
 
 

--- a/tests/unit/rules/test_rule_meta.py
+++ b/tests/unit/rules/test_rule_meta.py
@@ -51,6 +51,18 @@ def test_init(caplog):
             """
             return []
 
+        def _sync_and_validate_with_api(self):
+            """
+            Not needed / will not be used.
+            """
+            return True
+
+        def execute(self, force_test_report_only=False):
+            """
+            Not needed / will not be used.
+            """
+            return
+
     caplog.set_level(logging.WARNING)
     caplog.clear()
 
@@ -58,6 +70,7 @@ def test_init(caplog):
     assert blank_rule._rule_id == 'blank-rule-id'
     assert blank_rule._rule_type == 'blank-rule-type'
     assert blank_rule._test_report_only is True
+    assert blank_rule._is_valid is None
     assert caplog.record_tuples == []
 
     blank_extra_rule = BlankRule('blank-rule-id', 'blank-rule-type', True,
@@ -65,6 +78,7 @@ def test_init(caplog):
     assert blank_extra_rule._rule_id == 'blank-rule-id'
     assert blank_extra_rule._rule_type == 'blank-rule-type'
     assert blank_extra_rule._test_report_only is True
+    assert blank_rule._is_valid is None
     assert caplog.record_tuples == [
             ('asana_extensions.rules.rule_meta', logging.WARNING,
                 'Discarded excess kwargs provided to BlankRule: extras'),
@@ -105,6 +119,18 @@ def test_load_specific_from_conf(caplog):
             Not needed / will not be used.
             """
             return []
+
+        def _sync_and_validate_with_api(self):
+            """
+            Not needed / will not be used.
+            """
+            return True
+
+        def execute(self, force_test_report_only=False):
+            """
+            Not needed / will not be used.
+            """
+            return
 
     this_dir = os.path.dirname(os.path.realpath(__file__))
     conf_dir = os.path.join(this_dir, 'test_rule_meta')

--- a/tests/unit/rules/test_rules.py
+++ b/tests/unit/rules/test_rules.py
@@ -12,11 +12,17 @@ Module Attributes:
 
 (C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
+#pylint: disable=protected-access  # Allow for purpose of testing those elements
+
 import logging
 import os.path
 
 from asana_extensions.general import dirs
 from asana_extensions.rules import rules
+
+
+
+logger = logging.getLogger(__name__)
 
 
 
@@ -52,4 +58,64 @@ def test_load_all_from_config(monkeypatch, caplog):
             ('asana_extensions.rules.rules', logging.WARNING,
                 'Failed to match any rule type for rules.conf section'
                 + ' "test-no-rule-type"'),
+    ]
+
+
+
+def test_execute_rules(monkeypatch, caplog, blank_rule_cls):
+    """
+    Tests the `execute_rules() method.
+    """
+    def mock_execute(self, force_test_report_only=False):
+        """
+        Overrides execution to sometimes return failure or add log message.
+        """
+        if self._rule_type == 'bad-rule-type':
+            return False
+        if force_test_report_only:
+            logger.info(f'Test report only for {self._rule_id}')
+        return True
+
+    monkeypatch.setattr(blank_rule_cls, 'execute', mock_execute)
+
+    caplog.set_level(logging.INFO)
+
+    blank_rules = [
+        blank_rule_cls('blank-rule-id-1', 'good-rule-type', False),
+        blank_rule_cls('blank-rule-id-2', 'good-rule-type', False),
+        blank_rule_cls('blank-rule-id-3', 'bad-rule-type', True),
+        blank_rule_cls('blank-rule-id-4', 'good-rule-type', False),
+    ]
+
+    caplog.clear()
+    assert rules.execute_rules(blank_rules) is False
+    assert caplog.record_tuples == [
+        ('asana_extensions.rules.rules', logging.ERROR,
+            'Failure in fully executing "blank-rule-id-3".'),
+    ]
+
+    caplog.clear()
+    assert rules.execute_rules(blank_rules, True) is False
+    assert caplog.record_tuples == [
+        ('tests.unit.rules.test_rules', logging.INFO,
+            'Test report only for blank-rule-id-1'),
+        ('tests.unit.rules.test_rules', logging.INFO,
+            'Test report only for blank-rule-id-2'),
+        ('asana_extensions.rules.rules', logging.ERROR,
+            'Failure in fully executing "blank-rule-id-3".'),
+        ('tests.unit.rules.test_rules', logging.INFO,
+            'Test report only for blank-rule-id-4'),
+    ]
+
+    caplog.clear()
+    assert rules.execute_rules(blank_rules[3:]) is True
+    assert caplog.record_tuples == []
+
+    caplog.clear()
+    assert rules.execute_rules(blank_rules[:2], True) is True
+    assert caplog.record_tuples == [
+        ('tests.unit.rules.test_rules', logging.INFO,
+            'Test report only for blank-rule-id-1'),
+        ('tests.unit.rules.test_rules', logging.INFO,
+            'Test report only for blank-rule-id-2'),
     ]


### PR DESCRIPTION
This implements the actual logic to move tasks based on the move tasks rule, as well as to execute all rules.

This entailed some updates to the `Rule` meta-class, as well as a little refactoring of some test infrastructure for better reuse.

Closes #2.