### PR TITLE
feature/20-main into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,15 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
       ISO 8601 strings and `relativedelta` input only ([#18][]).
 
 
+### Main
+- [Added] `main.py` added to `/asana_extensions` for main entry point for app
+      ([#20][]).
+  - Set logger level based on CLI arg.
+  - Set whether to force test report only mode based on CLI arg.
+  - Execute modules based on CLI arg (so far, only `rules` or `all`).
+  - Shutdown signal handler added.
+
+
 ### Rules / Meta
 - [Added] `rule_meta.py` added with abstract `Rule` defining interface and some
       consolidated logic ([#1][]).
@@ -341,6 +350,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#16][]
 - [#18][]
 - [#19][]
+- [#20][]
 - [#25][]
 - [#27][]
 - [#28][]
@@ -361,6 +371,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#34][] for [#33][]
 - [#38][] for [#19][]
 - [#41][] for [#2][]
+- [#42][] for [#20][]
 
 
 ---
@@ -383,6 +394,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#33]: https://github.com/JonathanCasey/asana_extensions/issues/33 'Issue #33'
 [#19]: https://github.com/JonathanCasey/asana_extensions/issues/19 'Issue #19'
 [#2]: https://github.com/JonathanCasey/asana_extensions/issues/2 'Issue #2'
+[#20]: https://github.com/JonathanCasey/asana_extensions/issues/20 'Issue #20'
 
 [#6]: https://github.com/JonathanCasey/asana_extensions/pull/6 'PR #6'
 [#8]: https://github.com/JonathanCasey/asana_extensions/pull/8 'PR #8'
@@ -398,3 +410,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#34]: https://github.com/JonathanCasey/asana_extensions/pull/34 'PR #34'
 [#38]: https://github.com/JonathanCasey/asana_extensions/pull/38 'PR #38'
 [#41]: https://github.com/JonathanCasey/asana_extensions/pull/41 'PR #41'
+[#42]: https://github.com/JonathanCasey/asana_extensions/pull/42 'PR #42'

--- a/asana_extensions/__init__.py
+++ b/asana_extensions/__init__.py
@@ -1,3 +1,4 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
+    'main',
 ]

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -9,6 +9,7 @@ Module Attributes:
 
 (C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
 """
+import argparse
 import logging
 import signal
 import sys
@@ -27,36 +28,108 @@ else:
 
 
 
-def main():
+def main(force_test_report_only, log_level):
     """
     Launches the main app.
     """
+    _config_root_logger(log_level)
     all_rules = rules.load_all_from_config()
-    rules.execute_rules(all_rules)
+    rules.execute_rules(all_rules, force_test_report_only)
+    logger.info('Asana Extensions run complete!')
 
 
 
-def _setup_and_call_main():
+def _config_root_logger(log_level):
+    """
+    Configure the root logger.
+
+    Specifically, this sets the log level for the root logger so it will apply
+    to all loggers in this app.
+
+    Args:
+      log_level (Level/int/str): The desired log level.  This can be specified
+        as a level constant from the logging module, or it can be an int or str
+        reprenting the numeric value (possibly as a str) or textual name
+        (possibly with incorrect case) of the level.
+
+    Raises:
+      (TypeError): Invalid type provided for `log_level`.
+      (ValueError): Correct type provided for `log_level`, but is not a valid
+        supported value.
+    """
+    root_logger = logging.getLogger() # Root logger will config app-wide
+    try:
+        root_logger.setLevel(log_level)
+        return
+    except AssertionError:  # TODO: Set correct errors to handle
+        pass
+
+    try:
+        root_logger.setLevel(int(log_level))
+        return
+    except AssertionError:  # TODO: Set correct errors to handle
+        pass
+
+    try:
+        root_logger.setLevel(log_level.upper())
+        return
+    except AssertionError:  # TODO: Set correct errors to handle
+        pass
+
+    raise TypeError('Invalid log level type (somehow).  See --help for -l.')
+
+
+
+def _setup_and_call_main(_args=None):
     """
     Setup any pre-main operations, such as signals and input arg parsing, then
     call `main()`.  This is basically what would normally be in
     `if __name__ == '__main__':` prior to `main()` call, but this allows unit
     testing a lot more easily.
+
+    Args:
+      _args ([str] or None): The list of input args to parse.  Should only be
+        used by unit testing.  When executing, it is expected this stays as
+        `None` so it will default to taking args from `sys.argv` (i.e. from
+        CLI).
     """
     _register_shutdown_signals()
 
-    main()
+    parser = argparse.ArgumentParser(description='Process inputs.')
+    parser.add_argument('-e', '--execute',
+            dest='force_test_report_only',
+            action='store_const',
+            const=False,
+            default=True,
+            help='Execute the module(s).  Without this, it will run in test'
+                + ' report only mode.')
+    parser.add_argument('-l', '--log_level',
+            default=logging.WARNING,
+            help='Set the log level through the app.  Will only report logged'
+                + ' messages that are the specified level or more severe.'
+                + '  Defaults to "Warning".  Can specify by name or number to'
+                + ' match python `logging` module: notset/0, debug/10, info/20,'
+                + ' warning/30, error/40, critical/50.')
+
+    main(**vars(parser.parse_args(_args)))
 
 
 
-def _register_shutdown_signals():
+def _register_shutdown_signals(signals=None):
     """
     Registers the shutdown signals that will be supported, handling any platform
     dependent discrepancies gracefully.
+
+    Args:
+      signals ([str] or None): String of names of signals in `signal` module, or
+        `None` to use defaults.
     """
-    for sig in ('INT', 'TERM', 'QUIT', 'HUP'):
+    if signals is None:
+        signals = ('SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGHUP')
+
+    for sig in signals:
         try:
-            signal.signal(getattr(signal, f'SIG{sig}'), _shutdown)
+            signal.signal(getattr(signal, sig), _shutdown)
         except AttributeError:
             # Likely a platform didn't support one of the options
             continue

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -43,10 +43,23 @@ def _setup_and_call_main():
     `if __name__ == '__main__':` prior to `main()` call, but this allows unit
     testing a lot more easily.
     """
-    for sig in ('INT', 'TERM', 'QUIT', 'HUP'):
-        signal.signal(getattr(signal, 'SIG%s' % sig), _shutdown)
+    _register_shutdown_signals()
 
     main()
+
+
+
+def _register_shutdown_signals():
+    """
+    Registers the shutdown signals that will be supported, handling any platform
+    dependent discrepancies gracefully.
+    """
+    for sig in ('INT', 'TERM', 'QUIT', 'HUP'):
+        try:
+            signal.signal(getattr(signal, f'SIG{sig}'), _shutdown)
+        except AttributeError:
+            # Likely a platform didn't support one of the options
+            continue
 
 
 

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -142,7 +142,7 @@ def _setup_and_call_main(_args=None):
             default=True,
             help='Execute the module(s).  Without this, it will run in test'
                 + ' report only mode.')
-    parser.add_argument('-l', '--log_level',
+    parser.add_argument('-l', '--log-level',
             default=logging.WARNING,
             help='Set the log level through the app.  Will only report logged'
                 + ' messages that are the specified level or more severe.'

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -91,22 +91,20 @@ def _config_root_logger(log_level):
         supported value.
     """
     root_logger = logging.getLogger() # Root logger will config app-wide
-    try:
-        root_logger.setLevel(log_level)
-        return
-    except AssertionError:  # TODO: Set correct errors to handle
-        pass
-
-    try:
-        root_logger.setLevel(int(log_level))
-        return
-    except AssertionError:  # TODO: Set correct errors to handle
-        pass
 
     try:
         root_logger.setLevel(log_level.upper())
         return
-    except AssertionError:  # TODO: Set correct errors to handle
+    except AttributeError:
+        # Likely passed in an int, which has no method `upper()` -- retry below
+        pass
+    # ValueError is probably an "unknown level" from logger -- let it be raised
+
+    try:
+        root_logger.setLevel(int(log_level))
+        return
+    except ValueError:
+        # Probably an invalid type that couldn't be cast -- let fall thru
         pass
 
     raise TypeError('Invalid log level type (somehow).  See --help for -l.')

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -111,7 +111,7 @@ def _config_root_logger(log_level):
     try:
         root_logger.setLevel(int(log_level))
         return
-    except ValueError:
+    except (TypeError, ValueError):
         # Probably an invalid type that couldn't be cast -- let fall thru
         pass
 

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -43,12 +43,15 @@ def main(force_test_report_only, log_level, modules):
         arg parsing code in `_setup_and_call_main()` for details of options.
     """
     _config_root_logger(log_level)
-    any_errors = False
+    any_errors = None
 
     if any(x.lower() in ['rules', 'all'] for x in modules):
-        any_errors = _main_rules(force_test_report_only) or any_errors
+        any_errors = not _main_rules(force_test_report_only) \
+                or any_errors or False
 
-    if any_errors:
+    if any_errors is None:
+        logger.info('Asana Extensions had no modules to run -- fully skipped.')
+    elif any_errors:
         logger.warning('Asana Extensions run completed, but with errors...')
     else:
         logger.info('Asana Extensions run completed successfully!')

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -176,6 +176,8 @@ def _register_shutdown_signals(signals=None):
         try:
             signal.signal(getattr(signal, sig), _shutdown)
         except AttributeError:
+            logger.debug(f'Signal "{sig}" not registered for shutdown.  Likely'
+                    + ' not supported by this OS.')
             # Likely a platform didn't support one of the options
             continue
 

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -42,7 +42,12 @@ def main(force_test_report_only, log_level, modules):
       modules ([str]): The list of module names of what to execute.  See the
         arg parsing code in `_setup_and_call_main()` for details of options.
     """
-    _config_root_logger(log_level)
+    try:
+        _config_root_logger(log_level)
+    except (TypeError, ValueError) as ex:
+        _config_root_logger(logging.NOTSET)
+        logger.warning(f'Logger setting failed (Exception: {ex}).  Defaulting'
+                + ' to not set.')
     any_errors = None
 
     if any(x.lower() in ['rules', 'all'] for x in modules):

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+The main entry point for the package.
+
+Module Attributes:
+  _NAME_MOD_OVERRIDE (str): Name to use as override for `__name__` in select
+    cases since, in this module, `__name__` is often expected to be `__main__`.
+  logger (Logger): Logger for this module.
+
+(C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import logging
+
+from asana_extensions.rules import rules
+
+
+
+_NAME_MOD_OVERRIDE = 'asana_extensions.main'
+
+if __name__ == '__main__':                                  # Ignored by CodeCov
+    # Since no unit testing here, code kept at absolute minimum
+    logger = logging.getLogger(_NAME_MOD_OVERRIDE)
+else:
+    logger = logging.getLogger(__name__)
+
+
+
+def main():
+    """
+    Launches the main app.
+    """
+    all_rules = rules.load_all_from_config()
+    rules.execute_rules(all_rules)
+
+
+
+if __name__ == '__main__':                                  # Ignored by CodeCov
+    # Since no unit testing here, code kept at absolute minimum
+    main()

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -10,6 +10,8 @@ Module Attributes:
 (C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 import logging
+import signal
+import sys
 
 from asana_extensions.rules import rules
 
@@ -34,6 +36,37 @@ def main():
 
 
 
+def _setup_and_call_main():
+    """
+    Setup any pre-main operations, such as signals and input arg parsing, then
+    call `main()`.  This is basically what would normally be in
+    `if __name__ == '__main__':` prior to `main()` call, but this allows unit
+    testing a lot more easily.
+    """
+    for sig in ('INT', 'TERM', 'QUIT', 'HUP'):
+        signal.signal(getattr(signal, 'SIG%s' % sig), _shutdown)
+
+    main()
+
+
+
+def _shutdown(signum, _frame):
+    """
+    Perform all necessary operations to cleanly shutdown when required.
+
+    This is triggered through signal interrupts as registered when this is
+    executed as a script.
+
+    Args:
+      signum (int): Number of signal received.
+      _frame (frame): See signal.signal python docs.
+    """
+    msg = f'Exiting from signal {str(signum)} ...'
+    logger.warning(msg)
+    sys.exit(1)
+
+
+
 if __name__ == '__main__':                                  # Ignored by CodeCov
     # Since no unit testing here, code kept at absolute minimum
-    main()
+    _setup_and_call_main()

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -31,12 +31,44 @@ else:
 def main(force_test_report_only, log_level, modules):
     """
     Launches the main app.
+
+    Args:
+      force_test_report_only (bool): True to force test report only mode; False
+        to allow full execution (pending other settings).
+      log_level (Level/int/str): The desired log level.  This can be specified
+        as a level constant from the logging module, or it can be an int or str
+        reprenting the numeric value (possibly as a str) or textual name
+        (possibly with incorrect case) of the level.
+      modules ([str]): The list of module names of what to execute.  See the
+        arg parsing code in `_setup_and_call_main()` for details of options.
     """
     _config_root_logger(log_level)
+    any_errors = False
+
     if any(x.lower() in ['rules', 'all'] for x in modules):
-        all_rules = rules.load_all_from_config()
-        rules.execute_rules(all_rules, force_test_report_only)
-    logger.info('Asana Extensions run complete!')
+        any_errors = _main_rules(force_test_report_only) or any_errors
+
+    if any_errors:
+        logger.warning('Asana Extensions run completed, but with errors...')
+    else:
+        logger.info('Asana Extensions run completed successfully!')
+
+
+
+def _main_rules(force_test_report_only):
+    """
+    The main function for execution the rules modules.
+
+    Args:
+      force_test_report_only (bool): True to force test report only mode; False
+        to allow full execution (pending other settings).
+
+    Return:
+      (bool): True if fully successful (even in test report only mode); False if
+        any errors occurred that partially or fully prevented completion.
+    """
+    all_rules = rules.load_all_from_config()
+    return rules.execute_rules(all_rules, force_test_report_only)
 
 
 

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -28,13 +28,14 @@ else:
 
 
 
-def main(force_test_report_only, log_level):
+def main(force_test_report_only, log_level, modules):
     """
     Launches the main app.
     """
     _config_root_logger(log_level)
-    all_rules = rules.load_all_from_config()
-    rules.execute_rules(all_rules, force_test_report_only)
+    if any(x.lower() in ['rules', 'all'] for x in modules):
+        all_rules = rules.load_all_from_config()
+        rules.execute_rules(all_rules, force_test_report_only)
     logger.info('Asana Extensions run complete!')
 
 
@@ -110,6 +111,12 @@ def _setup_and_call_main(_args=None):
                 + '  Defaults to "Warning".  Can specify by name or number to'
                 + ' match python `logging` module: notset/0, debug/10, info/20,'
                 + ' warning/30, error/40, critical/50.')
+    parser.add_argument('-m', '--modules',
+            nargs='+',
+            help='The modules to run in this invocation.  Required.  Can'
+                + ' specify "all" to run all modules.  Otherwise, can provide a'
+                + ' space-separate list of module names.  Supported modules:'
+                + ' rules.')
 
     main(**vars(parser.parse_args(_args)))
 

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -50,7 +50,7 @@ def main(force_test_report_only, log_level, modules):
                 + ' to not set.')
     any_errors = None
 
-    if any(x.lower() in ['rules', 'all'] for x in modules):
+    if modules and any(x.lower() in ['rules', 'all'] for x in modules):
         any_errors = not _main_rules(force_test_report_only) \
                 or any_errors or False
 

--- a/asana_extensions/rules/move_tasks_rule.py
+++ b/asana_extensions/rules/move_tasks_rule.py
@@ -284,6 +284,11 @@ class MoveTasksRule(rule_meta.Rule):
         to be test report only, no changes will be made via the API -- only
         simulated results will be reported (but still based on data from API).
 
+        This should ideally catch all errors except ones so catastrophic that
+        the operation of the entire app should cease immediately.  Callers of
+        this method are not intended to require try/except handling for things
+        like mis-configured rules, etc.
+
         Args:
           force_test_report_only (bool): If True, will ensure this runs as a
             test report only with no changes made via the API; if False, will

--- a/asana_extensions/rules/rule_meta.py
+++ b/asana_extensions/rules/rule_meta.py
@@ -214,6 +214,11 @@ class Rule(ABC):
         to be test report only, no changes will be made via the API -- only
         simulated results will be reported (but still based on data from API).
 
+        This should ideally catch all errors except ones so catastrophic that
+        the operation of the entire app should cease immediately.  Callers of
+        this method are not intended to require try/except handling for things
+        like mis-configured rules, etc.
+
         Args:
           force_test_report_only (bool): If True, will ensure this runs as a
             test report only with no changes made via the API; if False, will

--- a/asana_extensions/rules/rules.py
+++ b/asana_extensions/rules/rules.py
@@ -28,6 +28,11 @@ def load_all_from_config(conf_rel_file='rules.conf'):
     """
     Loads all rules from the rules config file.
 
+    This should ideally catch all errors except ones so catastrophic that the
+    operation of the entire app should cease immediately.  Callers of this
+    method are not intended to require try/except handling for things like
+    mis-configured rules, etc.
+
     Args:
       conf_rel_file (str): The config file from which to load all rules.  Can
         omit to use default rule file name.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,3 +10,25 @@ These need to be run from the repo root to make paths work correctly.  E.g.:
 cd /path/to/repo/root
 python asana_extensions/main.py
 ```
+
+Use the above with `--help` to get the most updated list of command line (CLI)
+arguments.  As of writing, these are:
+
+- `-e`/`--execute`: Flag to fully perform actions, provided it is not configured
+      for test mode elsewhere, such as in an individual rule config.  Omitting
+      will default to test mode for everything.
+- `-l`/`--log-level <level>`: The log level to use for logging messages.  This
+      will log all messages at the specified level and more severe.  See the
+      help message or
+      [python logging docs](https://docs.python.org/3/library/logging.html#logging-levels)
+      for full list of options.
+- `-m`/`--modules <mod1> <mod2> ...`: The space-separated list of modules to run
+      in this invocation.  Omitting will result in nothing being run.  See the
+      help message for full and latest list of modules options, but they should
+      be:
+  - `all`: Run all modules.
+  - `rules`: Run the rules module.
+
+
+This project is developed with python 3.10, but it is very likely that earlier
+versions such as 3.6 and 3.7 work at this time.

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,3 +1,4 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
+    'test_main',
 ]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -16,6 +16,8 @@ Module Attributes:
 
 import logging
 
+import pytest
+
 from asana_extensions import main
 from asana_extensions.rules import rules as rules_mod
 
@@ -138,3 +140,39 @@ def test__main_rules(monkeypatch, caplog):
     assert caplog.record_tuples == [
         ('asana_extensions.rules.rules', logging.INFO, 'Test report only'),
     ]
+
+
+
+def test__config_root_logger():
+    """
+    Tests the `_config_root_logger()` method.
+    """
+    root_logger = logging.getLogger()
+    assert root_logger.getEffectiveLevel() == logging.WARNING
+
+    main._config_root_logger('info')
+    assert root_logger.getEffectiveLevel() == logging.INFO
+
+    main._config_root_logger(15)
+    assert root_logger.getEffectiveLevel() == 15
+
+    main._config_root_logger(10)
+    assert root_logger.getEffectiveLevel() == logging.DEBUG
+
+    with pytest.raises(ValueError) as ex:
+        main._config_root_logger('20')
+    assert "Unknown level: '20'" in str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        main._config_root_logger('invalid-level')
+    assert "Unknown level: 'INVALID-LEVEL'" in str(ex.value)
+
+    class Dummy:                        # pylint: disable=too-few-public-methods
+        """
+        Dummy class that does nothing.
+        """
+
+    with pytest.raises(TypeError) as ex:
+        main._config_root_logger(Dummy())
+    assert 'Invalid log level type (somehow).  See --help for -l.' \
+            in str(ex.value)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -15,6 +15,7 @@ Module Attributes:
 #pylint: disable=protected-access  # Allow for purpose of testing those elements
 
 import logging
+import signal
 
 import pytest
 
@@ -176,3 +177,25 @@ def test__config_root_logger():
         main._config_root_logger(Dummy())
     assert 'Invalid log level type (somehow).  See --help for -l.' \
             in str(ex.value)
+
+
+
+def test__shutdown(caplog):
+    """
+    Tests the `_shutdown()` method.
+
+    ...might be best to keep this to the end of the file.  It seems some code
+    intellisense doesn't like this handling of something that calls sys.exit()
+    and will instead assume nothing else can possibly run.  After all, what
+    comes after the end of the universe?
+    """
+    caplog.set_level(logging.WARNING)
+
+    caplog.clear()
+    with pytest.raises(SystemExit) as ex:
+        main._shutdown(signal.SIGINT, None)
+    assert '1' in str(ex.value)
+    assert caplog.record_tuples == [
+        ('asana_extensions.main', logging.WARNING,
+            'Exiting from signal Signals.SIGINT ...'),
+    ]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -21,6 +21,57 @@ from asana_extensions.rules import rules as rules_mod
 
 
 
+def test_global():
+    """
+    Tests items at the global scope not otherwise fully tested.
+    """
+    # Since only used (right now0 for logger name which is untested code, this
+    #  gives the best chance of detecting a mistake there.
+    assert main._NAME_MOD_OVERRIDE == 'asana_extensions.main'
+
+
+
+def test_main(monkeypatch, caplog):
+    """
+    Tests the `main()` method.
+    """
+    def mock__main_rules(force_test_report_only=False):
+        """
+        Return true/false, but do so based on test report arg for convenience.
+        """
+        return force_test_report_only
+
+    monkeypatch.setattr(main, '_main_rules', mock__main_rules)
+
+    caplog.set_level(logging.INFO)
+
+    caplog.clear()
+    main.main(False, logging.WARNING, [])
+    assert caplog.record_tuples == []
+
+    caplog.clear()
+    main.main(False, logging.INFO, [])
+    assert caplog.record_tuples == [
+        ('asana_extensions.main', logging.INFO,
+            'Asana Extensions had no modules to run -- fully skipped.'),
+    ]
+
+    caplog.clear()
+    main.main(False, logging.INFO, ['rules'])
+    assert caplog.record_tuples == [
+        ('asana_extensions.main', logging.WARNING,
+            'Asana Extensions run completed, but with errors...'),
+    ]
+
+    caplog.clear()
+    main.main(True, logging.INFO, ['all'])
+    assert caplog.record_tuples == [
+        ('asana_extensions.main', logging.INFO,
+            'Asana Extensions run completed successfully!'),
+    ]
+
+
+
 def test__main_rules(monkeypatch, caplog):
     """
     Tests the `_main_rules()` method.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Tests the asana_extensions.main functionality.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+#pylint: disable=protected-access  # Allow for purpose of testing those elements
+
+import logging
+
+from asana_extensions import main
+from asana_extensions.rules import rules as rules_mod
+
+
+
+def test__main_rules(monkeypatch, caplog):
+    """
+    Tests the `_main_rules()` method.
+    """
+    def mock_load_all_from_config_success(
+                conf_rel_file='rules.conf'):   # pylint: disable=unused-argument
+        """
+        Return some simple items to use as return "rules".
+        """
+        return [-1, -2]
+
+    def mock_load_all_from_config_failure(
+                conf_rel_file='rules.conf'):   # pylint: disable=unused-argument
+        """
+        Return some simple items to use as return "rules".
+        """
+        return [-3, -4]
+
+    def mock_execute_rules(rules, force_test_report_only=False):
+        """
+        Return True/False, but demonstrate args being used.
+        """
+        if force_test_report_only:
+            rules_mod.logger.info('Test report only')
+        if -3 in rules:
+            return False
+        return True
+
+    monkeypatch.setattr(rules_mod, 'load_all_from_config',
+            mock_load_all_from_config_success)
+    monkeypatch.setattr(rules_mod, 'execute_rules', mock_execute_rules)
+
+    caplog.set_level(logging.INFO)
+
+    caplog.clear()
+    assert main._main_rules(False) is True
+    assert caplog.record_tuples == []
+
+    caplog.clear()
+    assert main._main_rules(True) is True
+    assert caplog.record_tuples == [
+        ('asana_extensions.rules.rules', logging.INFO, 'Test report only'),
+    ]
+
+    monkeypatch.setattr(rules_mod, 'load_all_from_config',
+            mock_load_all_from_config_failure)
+
+    caplog.clear()
+    assert main._main_rules(False) is False
+    assert caplog.record_tuples == []
+
+    caplog.clear()
+    assert main._main_rules(True) is False
+    assert caplog.record_tuples == [
+        ('asana_extensions.rules.rules', logging.INFO, 'Test report only'),
+    ]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -236,7 +236,7 @@ def test__setup_and_call_main(monkeypatch, caplog):
 
     caplog.clear()
     main._setup_and_call_main(
-            '--modules rules all --log_level info --execute'.split())
+            '--modules rules all --log-level info --execute'.split())
     assert caplog.record_tuples == [
         (main_mod_name, logging.INFO, 'Force test report only: False'),
         (main_mod_name, logging.INFO, 'Log level: info'),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -70,6 +70,16 @@ def test_main(monkeypatch, caplog):
             'Asana Extensions run completed successfully!'),
     ]
 
+    caplog.clear()
+    main.main(False, 'bad log level', [])
+    assert caplog.record_tuples == [
+        ('asana_extensions.main', logging.WARNING,
+            "Logger setting failed (Exception: Unknown level: 'BAD LOG LEVEL')."
+                + "  Defaulting to not set."),
+        ('asana_extensions.main', logging.INFO,
+            'Asana Extensions had no modules to run -- fully skipped.'),
+    ]
+
 
 
 def test__main_rules(monkeypatch, caplog):


### PR DESCRIPTION
Adds `main.py` functionality.  This setups up system signal handling, CLI arg parsing, and executing all specified modules (right now, this is just 'rules').

Closes #20.