### PR TITLE
feature/37-asana-utl-deprec into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,9 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
       criteria ([#18][]).
 - [Added] `move_task_to_section()` added, with option to move to top or bottom
       ([#19][]).
+- [Changed] Asana API deprecation warning fixed by explicitly using the
+      `new_user_task_lists` (thereby dropping support for older user task list
+      version, which probably didn't work here anyways) ([#37][]).
 
 ##### Unit Tests
 - [Changed] `fixture_raise_no_authorization_error` and
@@ -355,6 +358,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#27][]
 - [#28][]
 - [#33][]
+- [#37][]
 
 #### PRs
 - [#6][] for [#5][]
@@ -372,6 +376,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#38][] for [#19][]
 - [#41][] for [#2][]
 - [#42][] for [#20][]
+- [#43][] for [#37][]
 
 
 ---
@@ -395,6 +400,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#19]: https://github.com/JonathanCasey/asana_extensions/issues/19 'Issue #19'
 [#2]: https://github.com/JonathanCasey/asana_extensions/issues/2 'Issue #2'
 [#20]: https://github.com/JonathanCasey/asana_extensions/issues/20 'Issue #20'
+[#37]: https://github.com/JonathanCasey/asana_extensions/issues/37 'Issue #37'
 
 [#6]: https://github.com/JonathanCasey/asana_extensions/pull/6 'PR #6'
 [#8]: https://github.com/JonathanCasey/asana_extensions/pull/8 'PR #8'
@@ -411,3 +417,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#38]: https://github.com/JonathanCasey/asana_extensions/pull/38 'PR #38'
 [#41]: https://github.com/JonathanCasey/asana_extensions/pull/41 'PR #41'
 [#42]: https://github.com/JonathanCasey/asana_extensions/pull/42 'PR #42'
+[#43]: https://github.com/JonathanCasey/asana_extensions/pull/43 'PR #43'

--- a/asana_extensions/asana/client.py
+++ b/asana_extensions/asana/client.py
@@ -88,9 +88,22 @@ def _get_client():
             parser = config.read_conf_file('.secrets.conf')
             pat = parser['asana']['personal access token']
             _get_client.client = asana.Client.access_token(pat)
+
+            asana_enable_to_add = ','.join([
+                'new_user_task_lists',
+            ])
+            if 'asana-enable' in _get_client.client.headers \
+                    and _get_client.client.headers['asana-enable']:
+                _get_client.client.headers['asana-enable'] = \
+                        _get_client.client.headers['asana-enable'] + ',' \
+                        + asana_enable_to_add
+            else:
+                _get_client.client.headers['asana-enable'] = asana_enable_to_add
+
         except KeyError as ex:
             raise ClientCreationError('Could not create client - Could not find'
                     + f' necessary section/key in .secrets.conf: {ex}') from ex
+
     return _get_client.client
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,3 +32,16 @@ arguments.  As of writing, these are:
 
 This project is developed with python 3.10, but it is very likely that earlier
 versions such as 3.6 and 3.7 work at this time.
+
+
+## Asana Support and Deprecations
+This project aims to stay up to date with API deprecations.  During the period
+of time between deprecation and removal of API items, this project may opt to
+fully switch away from deprecated features.
+
+At this time, the following are deprecated via the API, but this project has
+already migrated support and no longer supports the old methodology:
+- `new_user_task_lists`: This project now supports the "User Task List v2".
+      Support for the prior version user task list has been dropped.  For more
+      info, see
+      [this Asana forum thread](https://forum.asana.com/t/update-on-our-planned-api-changes-to-user-task-lists-a-k-a-my-tasks/103828).


### PR DESCRIPTION
This fixes the deprecation warning from the Asana API for the `new_user_task_lists` by forcing it to adopt the new method.

Resolves #37.