### PR TITLE
feature/52-add-version into develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,19 +192,6 @@ jobs:
             echo -e '\n[asana]\n' >> config/.secrets.conf
             echo -e 'personal access token : '$ASANA_PERSONAL_ACCESS_TOKEN'\n'  >> config/.secrets.conf
       - run:
-          name: Temp test git commands
-          command: |
-            git rev-parse --short HEAD
-            git symbolic-ref HEAD
-            git status --short
-      - run:
-          name: Temp test git commands with venv
-          command: |
-            . venv/bin/activate
-            git rev-parse --short HEAD
-            git symbolic-ref HEAD
-            git status --short
-      - run:
           name: Run pytest unit tests
           command: |
             . venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,20 +47,20 @@ workflows:
   version-format:
     jobs:
       - version-dev:
-        context:
-          - docker-hub-creds
-        filters:
-          branches:
-            ignore:
-              - stable
-              - /release\/.*/
+          context:
+            - docker-hub-creds
+          filters:
+            branches:
+              ignore:
+                - stable
+                - /release\/.*/
       - version-stable:
-        context:
-          - docker-hub-creds
-        filters:
-          branches:
-            only:
-              - stable
+          context:
+            - docker-hub-creds
+          filters:
+            branches:
+              only:
+                - stable
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,19 @@ jobs:
             echo -e '\n[asana]\n' >> config/.secrets.conf
             echo -e 'personal access token : '$ASANA_PERSONAL_ACCESS_TOKEN'\n'  >> config/.secrets.conf
       - run:
+          name: Temp test git commands
+          command: |
+            git rev-parse --short HEAD
+            git symbolic-ref HEAD
+            git status --short
+      - run:
+          name: Temp test git commands with venv
+          command: |
+            . venv/bin/activate
+            git rev-parse --short HEAD
+            git symbolic-ref HEAD
+            git status --short
+      - run:
           name: Run pytest unit tests
           command: |
             . venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,23 @@ workflows:
       - find-changelog-pr-ref:
           context:
             - docker-hub-creds
+  version-format:
+    jobs:
+      - version-dev:
+        context:
+          - docker-hub-creds
+        filters:
+          branches:
+            ignore:
+              - stable
+              - /release\/.*/
+      - version-stable:
+        context:
+          - docker-hub-creds
+        filters:
+          branches:
+            only:
+              - stable
 
 
 
@@ -236,3 +253,27 @@ jobs:
                 exit 1
               fi
             fi
+  version-dev:
+    <<: *default_python_image
+    steps:
+      - checkout
+      - *default_restore_cache
+      - *default_install_deps
+      - *default_save_cache
+      - run:
+          name: Run version checker with dev marker required
+          command: |
+            . venv/bin/activate
+            python ci_support/version_checker.py dev-required
+  version-stable:
+    <<: *default_python_image
+    steps:
+      - checkout
+      - *default_restore_cache
+      - *default_install_deps
+      - *default_save_cache
+      - run:
+          name: Run version checker with dev marker disallowed
+          command: |
+            . venv/bin/activate
+            python ci_support/version_checker.py dev-disallowed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,20 @@ aliases:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
 
+  - &default_python_git_image
+    docker:
+      - image: circleci/python:3.10
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          # By default there is no PYTHONPATH defined at all, so nothing to lose
+          PYTHONPATH: /home/circleci/project
+      - image: docker:stable-git
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+
   - &default_restore_cache
     restore_cache:
       key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
@@ -166,7 +180,7 @@ jobs:
             python ci_support/dir_init_checker.py ci_support
             python ci_support/dir_init_checker.py tests
   unit-tests:
-    <<: *default_python_image
+    <<: *default_python_git_image
     steps:
       - checkout
       - *default_restore_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Changed] Codecov uploader migrated from deprecated bash uploader to new
       uploader ([#28][]).
 - [Changed] Python version changed from 3.8 to 3.10 ([#33][]).
+- [Added] `version-format` workflow added to run `version-dev` and
+      `version-stable` jobs based on branch to confirm version format correct
+      ([#52][]).
+- [Added] `default_python_git_image` added to support new requirements for unit
+      tests that need python and git ([#52][]).
 
 
 ### Project & Toolchain: CI Support
@@ -62,6 +67,8 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
   - From groboclown; with modifications to add ignore for empty list as well as
         options for ignoring `if`, tuples, and functions.
   - Source code updated with fixes, but no functional changes.
+- [Added] `version_checker.py` added to verify that the version format conforms
+      to standard practice based on branch ([#52][]).
 
 
 ### Project & Toolchain: CodeCov
@@ -83,6 +90,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Added] `python-dateutil` added to `requirements.txt` ([#1][]).
 - [Added] `asana` added to `requirements.txt` ([#9][]).
 - [Changed] Python version changed from 3.7/3.8 to 3.10 ([#33][]).
+- [Added] `pytest-subprocess` added to `requirements.txt` ([#52][]).
 
 
 ### Project & Toolchain: Pylint
@@ -279,6 +287,8 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Fixed] In `_config_root_logger()`, raising the `ValueError` from string
       parsing is deferred until after trying int parsing so numbers passed as
       strings will work ([#46][]).
+- [Added] `--version` arg added to argparse to allow retrieving version string
+      or app/package, along with setting prog name ([#52][]).
 
 ##### Unit Tests
 - [Fixed] `fixture_ensure_logging_framework_not_altered()` added with `autouse`
@@ -346,6 +356,13 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
       ([#2][]).
 
 
+### Version
+(This does not need to note every version change, but can if issue tied to it.)
+- [Added] `version.py` added, with initial dev version set and methods to build
+      a full build version str including git status items ([#52][]).
+- [Added] Version initialized to `0.0.0` ([#52][]).
+
+
 ### Docs: CHANGELOG
 - [Added] This `CHANGELOG.md` file created and updated with all project work
       to-date (+1 self reference) ([#5][]).
@@ -362,6 +379,10 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [Added] Additional workflow steps and details added for additional
       modules/packages to pylint, as well as 2nd pytest invocation with
       `--run-no-warnings-only` ([#10][]).
+- [Added] Workflow steps updated with new version checker step (and filled in
+      missing dir init checker steps too) ([#52][]).
+- [Added] `Conventions` section added, with `Versioning` subsection to cover how
+      versioning is done ([#52][]).
 
 
 ### Docs: README
@@ -427,6 +448,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#48][]
 - [#49][]
 - [#51][]
+- [#52][]
 
 #### PRs
 - [#6][] for [#5][]
@@ -446,6 +468,7 @@ Compare to [stable](https://github.com/JonathanCasey/asana_extensions/compare/st
 - [#42][] for [#20][]
 - [#43][] for [#37][]
 - [#50][] for [#3][], [#44][], [#45][], [#46][], [#48][], [#49][], [#51][]
+- [#54][] for [#52][]
 
 
 ---
@@ -477,6 +500,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#48]: https://github.com/JonathanCasey/asana_extensions/issues/48 'Issue #48'
 [#49]: https://github.com/JonathanCasey/asana_extensions/issues/49 'Issue #49'
 [#51]: https://github.com/JonathanCasey/asana_extensions/issues/51 'Issue #51'
+[#52]: https://github.com/JonathanCasey/asana_extensions/issues/52 'Issue #52'
 
 [#6]: https://github.com/JonathanCasey/asana_extensions/pull/6 'PR #6'
 [#8]: https://github.com/JonathanCasey/asana_extensions/pull/8 'PR #8'
@@ -495,3 +519,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#42]: https://github.com/JonathanCasey/asana_extensions/pull/42 'PR #42'
 [#43]: https://github.com/JonathanCasey/asana_extensions/pull/43 'PR #43'
 [#50]: https://github.com/JonathanCasey/asana_extensions/pull/50 'PR #50'
+[#54]: https://github.com/JonathanCasey/asana_extensions/pull/54 'PR #54'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Respect the CI and the CI will respect you.
 
 - [One-time Setup](#one-time-setup)
 - [Usage](#usage)
+- [Conventions](#conventions)
 
 
 
@@ -121,3 +122,13 @@ development, it is most likely that `dev-required` is the correct arg.
 When running `pytest` without the `-p no:warnings` option, the warnings provided
 may be from `pytest`, but may also be from other packages, such as deprecation
 warnings from `asana`.
+
+
+
+# Conventions
+
+## Versioning
+See the top of `/asana_extensions/version.py` for information on the version
+information.  The general idea is that development versions must have a `+dev`
+appended while stable branch commits must not have this.  `release/*` branches
+are where this is allowed to be either to allow for the transition.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,9 +107,16 @@ python -m pylint asana_extensions
 python -m pylint tests
 python -m pylint ci_support
 python -m pylint conftest
+python ci_support/dir_init_checker.py asana_extensions
+python ci_support/dir_init_checker.py ci_support
+python ci_support/dir_init_checker.py tests
+python ci_support/version_checker.py dev-required
 pytest --cov=asana_extensions
 pytest --cov=asana_extensions --cov-append --run-no-warnings-only -p no:warnings
 ```
+
+The `version_checker.py` could be run with different args, but during
+development, it is most likely that `dev-required` is the correct arg.
 
 When running `pytest` without the `-p no:warnings` option, the warnings provided
 may be from `pytest`, but may also be from other packages, such as deprecation

--- a/asana_extensions/__init__.py
+++ b/asana_extensions/__init__.py
@@ -2,4 +2,5 @@
 __all__ = [
     '__main__',
     'main',
+    'version',
 ]

--- a/asana_extensions/main.py
+++ b/asana_extensions/main.py
@@ -14,6 +14,7 @@ import logging
 import signal
 import sys
 
+from asana_extensions import version
 from asana_extensions.general import config
 from asana_extensions.rules import rules
 
@@ -154,7 +155,8 @@ def _setup_and_call_main(_args=None):
     """
     _register_shutdown_signals()
 
-    parser = argparse.ArgumentParser(description='Process inputs.')
+    parser = argparse.ArgumentParser(description='Process inputs.',
+            prog='asana_extensions')
     parser.add_argument('-e', '--execute',
             dest='force_test_report_only',
             action='store_const',
@@ -175,6 +177,10 @@ def _setup_and_call_main(_args=None):
                 + ' specify "all" to run all modules.  Otherwise, can provide a'
                 + ' space-separate list of module names.  Supported modules:'
                 + ' rules.')
+    parser.add_argument('--version',
+            action='version',
+            version='%(prog)s ' + version.get_full_version_string(),
+            help='The version of this application/package.')
 
     main(**vars(parser.parse_args(_args)))
 

--- a/asana_extensions/version.py
+++ b/asana_extensions/version.py
@@ -8,9 +8,9 @@ attributes for the `version` attribute.
 Module Attributes:
   _VERSION (string): The current version of the code per SemVer.  Format should
     be `M.m.P-p`.  The `-p` can and should be omitted if it is `0`.  When in
-    development, a `+dev` should be appended to the version on which it is
-    based.  This should be removed as a last step on a `release/` branch before
-    merging into `stable`.
+    development, a `+dev` must be appended to the version on which it is based.
+    This should be removed as a last step on a `release/` branch and must be
+    removed before merging into `stable`.
 
 (C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
@@ -75,7 +75,7 @@ def _get_git_commit_hash():
                 capture_output=True, encoding='utf-8', check=True)
     except subprocess.CalledProcessError as ex:
         if ex.returncode == 1:
-            # No .git dir / not cloned
+            # No .git dir / not cloned / git not installed
             return 'x'
         raise
 
@@ -86,7 +86,7 @@ def _get_git_commit_hash():
 
 def _get_git_branch_code():
     """Gets the git branch and encodes into a code.
-    Format is the branch code of `m`aster, `d`evelop, or other `b`ranch.
+    Format is the branch code of `s`table, `d`evelop, or other `b`ranch.
     Detached head will be reported as `h`.  Git not being installed will be
     reported as `x`.
 
@@ -103,7 +103,7 @@ def _get_git_branch_code():
                 capture_output=True, encoding='utf-8', check=True)
     except subprocess.CalledProcessError as ex:
         if ex.returncode == 1:
-            # No .git dir / not cloned
+            # No .git dir / not cloned / git not installed
             return 'x'
         if ex.returncode == 128:
             # Detached head
@@ -144,7 +144,7 @@ def _get_git_status_code():
                 capture_output=True, encoding='utf-8', check=True)
     except subprocess.CalledProcessError as ex:
         if ex.returncode == 1:
-            # No .git dir / not cloned
+            # No .git dir / not cloned / git not installed
             return 'x-x'
         raise
 

--- a/asana_extensions/version.py
+++ b/asana_extensions/version.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""The version information for the code.
+
+The version most likely indicates the last release version.  It is encouraged
+during dev to use a pre-release of dev indication as noted below in the module
+attributes for the `version` attribute.
+
+Module Attributes:
+  _VERSION (string): The current version of the code per SemVer.  Format should
+    be `M.m.P-p`.  The `-p` can and should be omitted if it is `0`.  When in
+    development, a `+dev` should be appended to the version on which it is
+    based.  This should be removed as a last step on a `release/` branch before
+    merging into `stable`.
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import datetime as dt
+import re
+import subprocess
+
+from asana_extensions.general import dirs
+
+
+
+_VERSION = '0.0.0+dev'
+
+
+
+def get_full_version_string():
+    """Gets a version string that includes the intended version (or might be
+    most recent), the timestamp, and the git info string.
+
+    Returns:
+      (str): The string containing all version info for project.
+    """
+    timestamp = dt.datetime.now().strftime('%Y%m%d-%H%M%S')
+    return f'v{_VERSION}_{timestamp}_{_get_git_info_string()}'
+
+
+
+def _get_git_info_string():
+    """Gets an info string for the git status that includes the recent commit,
+    the branch, and the status of uncommitted changes.
+
+    Returns:
+      git_info (str): The git info string.
+    """
+    git_hash = _get_git_commit_hash()
+    git_branch_code = _get_git_branch_code()
+    git_status_code = _get_git_status_code()
+
+    git_info = f'{git_hash}-{git_branch_code}'
+    if git_status_code:
+        git_info += f'-{git_status_code}'
+
+    return git_info
+
+
+
+def _get_git_commit_hash():
+    """Gets the hash code for the most recent git commit on the current
+    branch/checkout.
+
+    Returns:
+      git_hash (str): The 7-character short git commit hash for the most recent
+        commit/checkout.  `x` if git is not installed.
+    """
+    result = subprocess.run(('git', 'rev-parse', '--short', 'HEAD'),
+            cwd=dirs.get_root_path(), shell=True,
+            capture_output=True, encoding='utf-8')
+
+    if result.returncode == 1:
+        return 'x'
+
+    git_hash = result.stdout.strip()
+    return git_hash
+
+
+
+def _get_git_branch_code():
+    """Gets the git branch and encodes into a code.
+    Format is the branch code of `m`aster, `d`evelop, or other `b`ranch.
+    Detached head will be reported as `h`.  Git not being installed will be
+    reported as `x`.
+
+    Return:
+      git_branch_code (str): The current git branch code.
+    """
+    result = subprocess.run(('git', 'symbolic-ref', 'HEAD'),
+            cwd=dirs.get_root_path(), shell=True,
+            capture_output=True, encoding='utf-8')
+
+    if result.returncode == 1:
+        return 'x'
+    if result.returncode == 128:
+        return 'h'
+
+    branch_ptn = re.compile('^refs/heads/')
+    git_branch = branch_ptn.sub('', result.stdout.strip())
+
+    if git_branch == 'stable':
+        return 's'
+    if git_branch == 'develop':
+        return 'd'
+    return 'b'
+
+
+
+def _get_git_status_code():
+    """Gets the git status and encodes general file states.
+
+    Format is `x-y`, where `x` is the listing of all `X` values from the short
+    git status, and `y` is the listing of all `Y` values from the short git
+    status.  Each section puts the letters in alphabetical order, and `?` is
+    replaced by `u`, and `!` is replaced by `i`.  See the git status docs for
+    more info on what `XY` codes are.
+
+    Returns:
+      git_status_code (str): The git status code summary string.  Literal `x-x`
+        if git is not installed.
+    """
+    result = subprocess.run(('git', 'status', '--short'),
+            cwd=dirs.get_root_path(), shell=True,
+            capture_output=True, encoding='utf-8')
+
+    if result.returncode == 1:
+        return 'x-x'
+
+    git_status = result.stdout  # Do NOT strip -- need leading whitespace!
+
+    x_codes = set()
+    y_codes = set()
+
+    for line in git_status.splitlines():
+        x = line[0].replace('?', 'u').replace('!', 'i')
+        y = line[1].replace('?', 'u').replace('!', 'i')
+
+        if x and x != ' ':
+            x_codes.add(x)
+
+        if y and y != ' ':
+            y_codes.add(y)
+
+    x_str = ''.join(sorted(x_codes))
+    y_str = ''.join(sorted(y_codes))
+
+    if not x_codes and not y_codes:
+        return ''
+
+    return f'{x_str}-{y_str}'

--- a/asana_extensions/version.py
+++ b/asana_extensions/version.py
@@ -71,8 +71,8 @@ def _get_git_commit_hash():
     """
     try:
         result = subprocess.run(('git', 'rev-parse', '--short', 'HEAD'),
-                cwd=dirs.get_root_path(), shell=True,
-                capture_output=True, encoding='utf-8', check=True)
+                cwd=dirs.get_root_path(), capture_output=True, encoding='utf-8',
+                check=True)
     except subprocess.CalledProcessError as ex:
         if ex.returncode == 1:
             # No .git dir / not cloned / git not installed
@@ -99,8 +99,8 @@ def _get_git_branch_code():
     """
     try:
         result = subprocess.run(('git', 'symbolic-ref', 'HEAD'),
-                cwd=dirs.get_root_path(), shell=True,
-                capture_output=True, encoding='utf-8', check=True)
+                cwd=dirs.get_root_path(), capture_output=True, encoding='utf-8',
+                check=True)
     except subprocess.CalledProcessError as ex:
         if ex.returncode == 1:
             # No .git dir / not cloned / git not installed
@@ -140,8 +140,8 @@ def _get_git_status_code():
     """
     try:
         result = subprocess.run(('git', 'status', '--short'),
-                cwd=dirs.get_root_path(), shell=True,
-                capture_output=True, encoding='utf-8', check=True)
+                cwd=dirs.get_root_path(), capture_output=True, encoding='utf-8',
+                check=True)
     except subprocess.CalledProcessError as ex:
         if ex.returncode == 1:
             # No .git dir / not cloned / git not installed

--- a/ci_support/__init__.py
+++ b/ci_support/__init__.py
@@ -2,4 +2,5 @@
 __all__ = [
         'dir_init_checker',
         'trailing_commas',
+        'version_checker',
 ]

--- a/ci_support/version_checker.py
+++ b/ci_support/version_checker.py
@@ -50,7 +50,7 @@ def main(dev_state):                         # pylint: disable=too-many-branches
         sys.exit(3)
 
     is_dev_valid = None
-    if len(full_ver_parts) == 1:
+    if len(dotted_ver_parts) == 2:
         is_dev_valid = is_version_dev_valid(dotted_ver_parts[1])
 
     if is_dev_valid is False:
@@ -132,7 +132,7 @@ def is_version_dev_valid(dotted_ver_dev):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Process inputs.')
-    parser.add_argument('dev-state',
+    parser.add_argument('dev_state',
             choices=['dev-disallowed', 'dev-required', 'dev-any'],
             help='Indicate the development state of the project for checking'
                 + ' if the version is appropriate.  It gives all 3 possibilies:'

--- a/ci_support/version_checker.py
+++ b/ci_support/version_checker.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Checks the version string to ensure it conforms to a valid format.
+
+This uses python import, so this must be called from a proper python env where
+the directories-under-test are accessible.  In other words, it is best to call
+from project root as
+`python3 ci_support/version_checker.py -d`.
+
+Entire file is excluded from unit testing / code cov; but is still linted.
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import argparse
+import re
+import sys
+
+from asana_extensions import version
+
+
+
+def main(dev_state):                         # pylint: disable=too-many-branches
+    """
+    Main entry point for this module.  Will check the version string and
+    validate it based on the provided args.
+
+    Args:
+      dev_state (str): The development state to check the version string format
+        against.  See the argparse argument choices for possible values.
+    """
+    full_ver_str = version.get_full_version_string()
+    full_ver_parts = full_ver_str.split('_')
+    if len(full_ver_parts) != 3:
+        print('Full version invalid.  Perhaps underscores were added?')
+        sys.exit(1)
+
+    dotted_ver_parts = full_ver_parts[0].split('+')
+
+    if not 0 < len(dotted_ver_parts) < 3:
+        print('Dotted (non-timestamp, non-git) portion invalid.  Perhaps more'
+                + ' than 1 plus (+) sign were added, or version is empty?')
+        sys.exit(2)
+
+    if not is_version_base_valid(dotted_ver_parts[0]):
+        print('Dotted (non-timestamp, non-git) portion does not conform to'
+                + ' psuedo-semver format (excluding possible dev marker).')
+        sys.exit(3)
+
+    is_dev_valid = None
+    if len(full_ver_parts) == 1:
+        is_dev_valid = is_version_dev_valid(dotted_ver_parts[1])
+
+    if is_dev_valid is False:
+        print('Invalid dev marker format.  Only allowed is `+dev`.')
+        sys.exit(4)
+
+    if dev_state == 'dev-disallowed':
+        if is_dev_valid is None:
+            print('Success: Confirmed dev marker disallowed.')
+            sys.exit(0)
+        if is_dev_valid is True:
+            print('Failure: Dev disallowed, but dev marker present.')
+            sys.exit(5)
+        print('Failure: Unknown failure in check dev disallowed.')
+        sys.exit(6)
+
+    if dev_state == 'dev-required':
+        if is_dev_valid is True:
+            print('Success: Confirmed dev marker required.')
+            sys.exit(0)
+        if is_dev_valid is None:
+            print('Failure: Dev required, but dev marker missing.')
+            sys.exit(7)
+        print('Failure: Unknown failure in check dev required.')
+        sys.exit(8)
+
+    if dev_state == 'dev-any':
+        if is_dev_valid is True or is_dev_valid is None:
+            print('Success: Confirmed dev marker can be present or missing.')
+            sys.exit(0)
+        print('Failure: Unknown failure in check dev any.')
+        sys.exit(9)
+
+    print('Failure: Unknown failure due to unexpected dev_state value.')
+    sys.exit(10)
+
+
+
+def is_version_base_valid(dotted_ver_no_dev):
+    """
+    Checks if the base version is a valid format.  This should be roughly
+    semver per the notes in `version.py`.
+
+    Args:
+      dotted_ver_no_dev (str): The version string to check, such as `v1.2.3-4`.
+        This should exclude anything after the `+` sign if applicable.
+
+    Returns:
+      (bool): True if version string is a valid format; False otherwise.
+    """
+    return re.match(r'^v[0-9x]+.[0-9x]+.[0-9x]+(-[0-9a-z]+)?$',
+            dotted_ver_no_dev) is not None
+
+
+
+def is_version_dev_valid(dotted_ver_dev):
+    """
+    Checks if the development marker is valid.
+
+    Args:
+      dotted_ver_dev (str): The dev marker portion of the version string to
+        check.  This should have already stripped the plus (`+`) sign that needs
+        to immediately precede it.
+
+    Returns:
+      (bool or None): True if the dev marker is present and is the correct
+        format; False if there is text but it is the wrong format; None if the
+        string is empty.
+    """
+    if not dotted_ver_dev:
+        return None
+
+    if dotted_ver_dev.lower() == 'dev':
+        return True
+
+    return False
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Process inputs.')
+    parser.add_argument('dev-state',
+            choices=['dev-disallowed', 'dev-required', 'dev-any'],
+            help='Indicate the development state of the project for checking'
+                + ' if the version is appropriate.  It gives all 3 possibilies:'
+                + ' disallowed, required, or does not matter.')
+
+    main(**vars(parser.parse_args()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ asana
 pylint
 pytest
 pytest-cov
+pytest-subprocess
 python-dateutil

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2,4 +2,5 @@
 __all__ = [
     'test__main__',
     'test_main',
+    'test_version',
 ]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -20,6 +20,7 @@ import signal
 import pytest
 
 from asana_extensions import main
+from asana_extensions import version
 from asana_extensions.rules import rules as rules_mod
 
 
@@ -227,7 +228,7 @@ def test__config_root_logger(capsys):
 
 
 
-def test__setup_and_call_main(monkeypatch, caplog):
+def test__setup_and_call_main(monkeypatch, caplog, capsys):
     """
     Tests the `_setup_and_call_main()` method.
     """
@@ -282,6 +283,16 @@ def test__setup_and_call_main(monkeypatch, caplog):
         (main_mod_name, logging.INFO, 'Log level: info'),
         (main_mod_name, logging.INFO, "Modules: `rules`|`all`"),
     ]
+
+    caplog.clear()
+    with pytest.raises(SystemExit) as ex:
+        main._setup_and_call_main('--version'.split())
+    assert caplog.record_tuples == []
+    stdout, _ = capsys.readouterr()
+    ver_parts = stdout.split('_')
+    assert ver_parts[0] == 'asana'
+    assert ver_parts[1] == f'extensions v{version._VERSION}'
+    assert len(ver_parts) == 4
 
 
 

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -15,6 +15,7 @@ Module Attributes:
 #pylint: disable=protected-access  # Allow for purpose of testing those elements
 
 import datetime as dt
+import re
 
 from asana_extensions import version
 
@@ -29,3 +30,87 @@ def test_get_full_version_string():
     assert 'v' + version._VERSION == full_ver_str_parts[0]
     dt.datetime.strptime(full_ver_str_parts[1], '%Y%m%d-%H%M%S')
     assert version._get_git_info_string() == full_ver_str_parts[2]
+
+
+
+def test__get_git_info_string(monkeypatch):
+    """
+    Tests the `_get_git_info_string()` method.
+    """
+    def mock__get_git_commit_hash():
+        """
+        Return a uniquely identifiable string for this test.
+        """
+        return 'hash'
+
+    def mock__get_git_branch_code():
+        """
+        Return a uniquely identifiable string for this test.
+        """
+        return 'branch'
+
+    def mock__get_git_status_code():
+        """
+        Return a uniquely identifiable string for this test.
+        """
+        return 'status'
+
+    monkeypatch.setattr(version, '_get_git_commit_hash',
+            mock__get_git_commit_hash)
+    monkeypatch.setattr(version, '_get_git_branch_code',
+            mock__get_git_branch_code)
+    monkeypatch.setattr(version, '_get_git_status_code',
+            mock__get_git_status_code)
+
+    assert version._get_git_info_string() == 'hash-branch-status'
+
+    def mock__get_git_status_code__empty():
+        """
+        Return an emtpy status code
+        """
+        return ''
+
+    monkeypatch.setattr(version, '_get_git_status_code',
+            mock__get_git_status_code__empty)
+
+    assert version._get_git_info_string() == 'hash-branch'
+
+
+
+def test__get_git_commit_hash__real():
+    """
+    Tests the `_get_git_commit_hash()` method.
+
+    This will test to make sure it can really get a commit hash.  It may vary
+    from test to test, but since this should always be run in a git repo, it
+    should pass.
+    """
+    git_commit_hash = version._get_git_commit_hash()
+    assert re.match(r'^[0-9a-f]{7}$', git_commit_hash) is not None
+
+
+
+def test__get_git_branch_code__real():
+    """
+    Tests the `_get_git_branch_code()` method.
+
+    This will test to make sure it can really get a branch code.  It may vary
+    from test to test, but since this should always be run in a git repo, it
+    should pass.
+    """
+    git_branch_code = version._get_git_branch_code()
+    assert any(git_branch_code == c for c in ['b', 'd', 'h', 's']) is True
+
+
+
+def test__get_git_status_code__real():
+    """
+    Tests the `_get_git_status_code()` method.
+
+    This will test to make sure it can really get a status code.  It may vary
+    from test to test, but since this should always be run in a git repo, it
+    should pass.
+    """
+    git_status_code = version._get_git_status_code()
+    assert re.match(r'^[ACDMRUiu]*-[ACDMRUiu]*$', git_status_code) is not None \
+            or git_status_code == ''

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+Tests the asana_extensions.version functionality.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+#pylint: disable=protected-access  # Allow for purpose of testing those elements
+
+import datetime as dt
+
+from asana_extensions import version
+
+
+
+def test_get_full_version_string():
+    """
+    Tests the `get_full_version_string()` method.
+    """
+    full_ver_str = version.get_full_version_string()
+    full_ver_str_parts = full_ver_str.split('_')
+    assert 'v' + version._VERSION == full_ver_str_parts[0]
+    dt.datetime.strptime(full_ver_str_parts[1], '%Y%m%d-%H%M%S')
+    assert version._get_git_info_string() == full_ver_str_parts[2]


### PR DESCRIPTION
This adds a version string.  It also adds accessing that version via argparse input from CLI.  It also adds new circleci workflow/jobs for checking the format to make sure it is correct based on the branch.

Closes #52.